### PR TITLE
fix: prevent duplicate notifications on launch by persisting hook-event offset

### DIFF
--- a/src-tauri/src/data/mod.rs
+++ b/src-tauri/src/data/mod.rs
@@ -10,3 +10,4 @@ pub mod tasks;
 pub mod teams;
 pub mod todos;
 pub mod transcripts;
+pub mod watcher_state;

--- a/src-tauri/src/data/watcher_state.rs
+++ b/src-tauri/src/data/watcher_state.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct WatcherState {
+    #[serde(default)]
+    pub hook_offsets: HashMap<String, u64>,
+}
+
+impl WatcherState {
+    pub fn load(ide_dir: &Path) -> Self {
+        let path = ide_dir.join("watcher-state.json");
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self, ide_dir: &Path) {
+        let path = ide_dir.join("watcher-state.json");
+        if let Ok(json) = serde_json::to_string(self) {
+            std::fs::write(path, json).ok();
+        }
+    }
+
+    pub fn get_offset(&self, key: &str) -> Option<u64> {
+        self.hook_offsets.get(key).copied()
+    }
+
+    pub fn set_offset(&mut self, key: String, offset: u64) {
+        self.hook_offsets.insert(key, offset);
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the ephemeral `last_hook_offset: u64 = 0` (reset every launch) with a `WatcherState` struct that persists per-file byte offsets to `~/.claude/theassociate/watcher-state.json`
- On first sight of a `hook-events.jsonl` file, the watcher records end-of-file and skips all historical events — no duplicate notifications
- On subsequent launches, resumes from the saved offset so only genuinely new `Stop` events are processed
- Fixes the multi-project bug: offsets are keyed by full file path (`HashMap<String, u64>`) rather than a single shared variable

## Files changed

| File | Change |
|---|---|
| `src-tauri/src/data/watcher_state.rs` | New — `WatcherState` with load/save/get/set helpers |
| `src-tauri/src/data/mod.rs` | +1 line: `pub mod watcher_state;` |
| `src-tauri/src/watcher/claude_watcher.rs` | Load state before thread spawn; replace single-offset branch with per-path offset logic |

## Test plan

- [ ] Launch app — verify no completion notifications appear for past sessions
- [ ] Run a Claude session to completion — verify a new notification IS generated
- [ ] Restart app — verify the notification does NOT re-appear
- [ ] Check `~/.claude/theassociate/watcher-state.json` exists with correct file offsets

🤖 Generated with [Claude Code](https://claude.com/claude-code)