### PR TITLE
feat: organize branch dropdown with folder structure for easier navigation

### DIFF
--- a/src/components/shell/TitleBar.tsx
+++ b/src/components/shell/TitleBar.tsx
@@ -226,7 +226,7 @@ function BranchDropdown({
   );
 
   const remoteTree = useMemo(
-    () => buildBranchTree(remoteOnlyBranches.map((rb) => rb.branch)),
+    () => buildBranchTree(remoteOnlyBranches.map((rb) => rb.fullRef)),
     [remoteOnlyBranches]
   );
 


### PR DESCRIPTION
Branches containing `/` are now grouped into expandable folders in the
git branch dropdown. The dropdown shows two sections — Local and Remote
(branches not pulled locally) — each with a collapsible tree. The folder
containing the current branch auto-expands on open, and each folder
shows a leaf count badge.

https://claude.ai/code/session_01Xq6ketW5ord1XQ7rTgB9Pb