### PR TITLE
feat: add "live dangerously" setting to skip Claude permissions

### DIFF
--- a/src/components/settings/SettingsTab.tsx
+++ b/src/components/settings/SettingsTab.tsx
@@ -603,6 +603,34 @@ function SessionTrackingSection() {
   );
 }
 
+// ── Live dangerously section ──────────────────────────────────────────────────
+
+function LiveDangerouslySection() {
+  const { dangerouslySkipPermissions, setDangerouslySkipPermissions } = useSettingsStore();
+
+  return (
+    <div className="space-y-3">
+      <SectionLabel>Permissions</SectionLabel>
+      <div>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={dangerouslySkipPermissions}
+            onChange={(e) => setDangerouslySkipPermissions(e.target.checked)}
+            className="rounded-md"
+          />
+          <span className="text-xs font-medium text-text-secondary">
+            Live dangerously (skip permissions)
+          </span>
+        </label>
+        <p className="text-[11px] text-text-muted mt-1 ml-5">
+          Passes <code className="text-[10px] bg-bg-raised px-1 rounded-md">--dangerously-skip-permissions</code> to every new Claude session. Skips all tool-use approval prompts.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 // ── Sticky section header ─────────────────────────────────────────────────────
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
@@ -757,7 +785,10 @@ export function SettingsTab() {
         {/* ── Session ────────────────────────────────────────────── */}
         <section>
           <SectionHeader>Session</SectionHeader>
-          <SessionTrackingSection />
+          <div className="space-y-6">
+            <SessionTrackingSection />
+            <LiveDangerouslySection />
+          </div>
         </section>
       </div>
     </div>

--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -23,6 +23,7 @@ export function TerminalView({ sessionId, resumeSessionId, cwd, isActive }: Term
   const lastDimsRef = useRef({ rows: 24, cols: 80 });
   const fontSize = useSettingsStore((s) => s.fontSize);
   const fontFamily = useSettingsStore((s) => s.fontFamily);
+  const dangerouslySkipPermissions = useSettingsStore((s) => s.dangerouslySkipPermissions);
   const fontSizeRef = useRef(fontSize);
   const fontFamilyRef = useRef(fontFamily);
 
@@ -107,6 +108,7 @@ export function TerminalView({ sessionId, resumeSessionId, cwd, isActive }: Term
       cwd,
       rows: dims.rows,
       cols: dims.cols,
+      skipPermissions: dangerouslySkipPermissions,
     }).catch((e: unknown) => {
       term.writeln(`\x1b[31mFailed to start Claude: ${e}\x1b[0m`);
     });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -8,6 +8,7 @@ interface SettingsStore {
   fontSize: number;
   fontFamily: string;
   openStartupFiles: boolean;
+  dangerouslySkipPermissions: boolean;
 
   // GitHub (token in Windows Credential Manager, rest in settings.json)
   githubClientId: string;
@@ -28,6 +29,7 @@ interface SettingsStore {
   setFontSize: (size: number) => void;
   setFontFamily: (family: string) => void;
   setOpenStartupFiles: (value: boolean) => void;
+  setDangerouslySkipPermissions: (value: boolean) => void;
   setGithubClientId: (id: string) => void;
   setGithubToken: (token: string) => void;
   setGithubUsername: (name: string | null) => void;
@@ -44,6 +46,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   fontSize: 14,
   fontFamily: "Cascadia Code, JetBrains Mono, Fira Code, monospace",
   openStartupFiles: false,
+  dangerouslySkipPermissions: false,
   githubClientId: "",
   githubToken: "",
   githubUsername: null,
@@ -56,19 +59,23 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
   setFontSize: (fontSize) => {
     set({ fontSize });
-    persistConfig({ fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles });
+    persistConfig({ fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
   },
   setFontFamily: (fontFamily) => {
     set({ fontFamily });
-    persistConfig({ fontSize: get().fontSize, fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles });
+    persistConfig({ fontSize: get().fontSize, fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
   },
   setOpenStartupFiles: (openStartupFiles) => {
     set({ openStartupFiles });
-    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
+  },
+  setDangerouslySkipPermissions: (dangerouslySkipPermissions) => {
+    set({ dangerouslySkipPermissions });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions });
   },
   setGithubClientId: (githubClientId) => {
     set({ githubClientId });
-    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
   },
   setGithubToken: (githubToken) => set({ githubToken }),
   setGithubUsername: (githubUsername) => set({ githubUsername }),
@@ -76,11 +83,11 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   setLinearUsername: (linearUsername) => set({ linearUsername }),
   setJiraBaseUrl: (jiraBaseUrl) => {
     set({ jiraBaseUrl });
-    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
   },
   setJiraEmail: (jiraEmail) => {
     set({ jiraEmail });
-    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail, openStartupFiles: get().openStartupFiles });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
   },
   setJiraApiToken: (jiraApiToken) => set({ jiraApiToken }),
   setJiraUsername: (jiraUsername) => set({ jiraUsername }),
@@ -96,6 +103,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       const jiraBaseUrl = await store.get<string>("jiraBaseUrl");
       const jiraEmail = await store.get<string>("jiraEmail");
       const openStartupFiles = await store.get<boolean>("openStartupFiles");
+      const dangerouslySkipPermissions = await store.get<boolean>("dangerouslySkipPermissions");
       set({
         ...(fontSize != null && { fontSize }),
         ...(fontFamily != null && { fontFamily }),
@@ -103,6 +111,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         ...(jiraBaseUrl != null && { jiraBaseUrl }),
         ...(jiraEmail != null && { jiraEmail }),
         ...(openStartupFiles != null && { openStartupFiles }),
+        ...(dangerouslySkipPermissions != null && { dangerouslySkipPermissions }),
       });
       debugLog("Settings", "Config loaded from disk", { fontSize, fontFamily, githubClientId }, "success");
     } catch {
@@ -135,6 +144,7 @@ interface Config {
   jiraBaseUrl: string;
   jiraEmail: string;
   openStartupFiles: boolean;
+  dangerouslySkipPermissions: boolean;
 }
 
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -151,6 +161,7 @@ function persistConfig(config: Config) {
       await store.set("jiraBaseUrl", config.jiraBaseUrl);
       await store.set("jiraEmail", config.jiraEmail);
       await store.set("openStartupFiles", config.openStartupFiles);
+      await store.set("dangerouslySkipPermissions", config.dangerouslySkipPermissions);
       await store.save();
     } catch {
       // not in Tauri context


### PR DESCRIPTION
## Summary

- Adds a **persistent "Live dangerously" checkbox** in Settings → Session that passes `--dangerously-skip-permissions` to every new Claude PTY session
- Setting persists across app restarts via `settings.json`
- Also includes pre-existing work: `pty_kill_all` command + window `Destroyed` hook to clean up PTY sessions on app close

## Changes

| File | Change |
|------|--------|
| `src/stores/settingsStore.ts` | `dangerouslySkipPermissions` field, setter, and `settings.json` persistence |
| `src/components/settings/SettingsTab.tsx` | `LiveDangerouslySection` component in the Session section |
| `src-tauri/src/commands/pty.rs` | `skip_permissions: bool` param → conditionally appends `--dangerously-skip-permissions`; adds `pty_kill_all` |
| `src/components/terminal/TerminalView.tsx` | Reads setting from store; passes `skipPermissions` to `pty_spawn` |
| `src-tauri/src/lib.rs` | Registers `pty_kill_all`; kills all PTY sessions on window `Destroyed` |

## Test plan

- [ ] Open Settings → Session → confirm "Live dangerously (skip permissions)" checkbox appears
- [ ] Enable it, restart app → confirm checkbox is still checked
- [ ] Start a new Claude session → run a tool that normally prompts for permission → confirm it proceeds without prompting
- [ ] Disable setting → start another session → confirm permission prompts return
- [ ] Close the app with active sessions → confirm no orphaned `claude` processes remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)