### PR TITLE
feat: dedicated Docs right-panel tab with table-of-contents view

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -10,7 +10,7 @@ pub struct FileEntry {
 }
 
 #[tauri::command]
-pub async fn cmd_list_dir(path: String) -> Result<Vec<FileEntry>, String> {
+pub async fn cmd_list_dir(path: String, show_hidden: bool) -> Result<Vec<FileEntry>, String> {
     let dir = std::path::Path::new(&path);
     if !dir.is_dir() {
         return Err(format!("Not a directory: {}", path));
@@ -24,8 +24,8 @@ pub async fn cmd_list_dir(path: String) -> Result<Vec<FileEntry>, String> {
         let entry = entry.map_err(|e| e.to_string())?;
         let name = entry.file_name().to_string_lossy().to_string();
 
-        // Skip hidden files/dirs (starting with .)
-        if name.starts_with('.') {
+        // Skip hidden files/dirs (starting with .) — only when show_hidden is false
+        if !show_hidden && name.starts_with('.') {
             continue;
         }
 

--- a/src/components/context/ContextPanel.tsx
+++ b/src/components/context/ContextPanel.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Wrench, CheckSquare, Brain, MessageSquare, ChevronDown, ChevronRight } from "lucide-react";
-import { DocsSection } from "./DocsSection";
 import { useQuery } from "@tanstack/react-query";
 import { useTranscript, useTodos, useTeams, useTasks } from "../../hooks/useClaudeData";
 import { useActiveProjectTabs } from "../../hooks/useActiveProjectTabs";
@@ -156,14 +155,6 @@ export function ContextPanel() {
       {activeProjectDir && homeDir && (
         <MemorySection
           homeDir={homeDir}
-          activeProjectDir={activeProjectDir}
-          activeProjectId={activeProjectId}
-        />
-      )}
-
-      {/* Docs section */}
-      {activeProjectDir && (
-        <DocsSection
           activeProjectDir={activeProjectDir}
           activeProjectId={activeProjectId}
         />

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -3,6 +3,28 @@ import { useUIStore } from "@/stores/uiStore";
 import { ContextPanel } from "@/components/context/ContextPanel";
 import { TeamsRightPanel } from "@/components/context/TeamsRightPanel";
 import { PlansPanel } from "@/components/context/PlansPanel";
+import { DocsSection } from "@/components/context/DocsSection";
+import { useProjectsStore } from "@/stores/projectsStore";
+
+function DocsTabPanel() {
+  const activeProject = useProjectsStore((s) =>
+    s.projects.find((p) => p.id === s.activeProjectId)
+  );
+  const activeProjectId = useProjectsStore((s) => s.activeProjectId ?? "");
+  if (!activeProject) {
+    return (
+      <div className="p-3 text-xs text-[var(--color-text-muted)] text-center">
+        Open a project to browse docs
+      </div>
+    );
+  }
+  return (
+    <DocsSection
+      activeProjectDir={activeProject.path}
+      activeProjectId={activeProjectId}
+    />
+  );
+}
 
 function RightPanelComponent() {
   const activeTab = useUIStore((s) => s.activeRightTab);
@@ -16,6 +38,7 @@ function RightPanelComponent() {
         {activeTab === "context" && <ContextPanel />}
         {activeTab === "teams" && <TeamsRightPanel />}
         {activeTab === "plans" && <PlansPanel />}
+        {activeTab === "docs" && <DocsTabPanel />}
       </div>
     </div>
   );

--- a/src/components/shell/RightActivityBar.tsx
+++ b/src/components/shell/RightActivityBar.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Brain, Users, FileText } from "lucide-react";
+import { Brain, Users, FileText, BookOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useUIStore, type RightTab } from "@/stores/uiStore";
 
@@ -13,6 +13,7 @@ const rightItems: RightActivityItem[] = [
   { id: "context", icon: Brain, label: "Context" },
   { id: "teams", icon: Users, label: "Teams" },
   { id: "plans", icon: FileText, label: "Plans" },
+  { id: "docs", icon: BookOpen, label: "Docs" },
 ];
 
 function RightActivityBarComponent() {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -514,8 +514,8 @@ export function writeFile(path: string, content: string): Promise<void> {
 
 // ---- File Browser Wrappers ----
 
-export function listDir(path: string): Promise<FileEntry[]> {
-  return invoke("cmd_list_dir", { path });
+export function listDir(path: string, showHidden = false): Promise<FileEntry[]> {
+  return invoke("cmd_list_dir", { path, showHidden });
 }
 
 export function getHomeDir(): Promise<string> {

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
 export type SidebarView = "sessions" | "git" | "prs" | "files";
-export type RightTab = "context" | "teams" | "plans";
+export type RightTab = "context" | "teams" | "plans" | "docs";
 export type BottomTab = "log" | "git" | "prs" | "issues" | "output" | "debug";
 
 export interface SelectedDiffFile {


### PR DESCRIPTION
## Summary

- **New Docs tab** — BookOpen button in the right activity bar opens a dedicated Docs panel (previously buried inside the Context tab)
- **Table-of-contents style** — file list uses `Folder`/`FileText` icons with folder expand/collapse; replaces the generic `FileTreeNode` component
- **Humanized names** — `humanizeName()` converts `coding-standards.md` → "Coding Standards", `IdentityServer` → "Identity Server", `webForms` → "Web Forms" (handles camelCase, PascalCase, kebab, snake)
- **Smart file opening** — `.md` files open in the markdown viewer (`type: "readme"`), all other files open in Monaco editor (`type: "file"`)
- **Full-panel layout** — `DocsSection` now fills the right panel height with a scrollable file list; removed from `ContextPanel`
- **Show hidden files toggle** — `FileBrowserPanel` gains an Eye/EyeOff button; `listDir` / `cmd_list_dir` accept an optional `show_hidden` param

## Test plan

- [ ] Open a project — confirm BookOpen "Docs" button appears in right activity bar
- [ ] Click Docs — panel opens showing the configured/auto-detected docs folder
- [ ] Confirm Context tab no longer shows a Docs section
- [ ] Confirm file names are humanized (`coding-standards.md` → "Coding Standards")
- [ ] Click a `.md` file — opens in markdown view (rendered)
- [ ] Click a non-`.md` file — opens in Monaco editor
- [ ] Confirm folder expand/collapse works with the new chevron+folder-icon style
- [ ] In File Browser, toggle Eye icon — hidden dotfiles appear/disappear
- [ ] Docs panel folder edit (pencil), save, and "Generate with Claude" still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)