### PR TITLE
feat: terminal-aware keybindings + clipboard paste/copy support

### DIFF
--- a/src/hooks/useKeyBindings.ts
+++ b/src/hooks/useKeyBindings.ts
@@ -16,12 +16,13 @@ export function useKeyBindings() {
       const ctrl = e.ctrlKey || e.metaKey;
       const shift = e.shiftKey;
 
-      // Don't intercept when typing in inputs/textareas
       const target = e.target as HTMLElement;
-      const inInput =
-        target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.isContentEditable;
+      const isXtermFocused = !!target.closest?.(".xterm");
+      const inRegularInput =
+        !isXtermFocused &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable);
 
       // Command palette -- always intercept
       if (ctrl && e.key === "p" && !shift) {
@@ -52,7 +53,19 @@ export function useKeyBindings() {
         }
       }
 
-      if (inInput) return;
+      // Block everything in regular inputs
+      if (inRegularInput) return;
+
+      // In xterm: only terminal-safe keybindings pass through
+      if (isXtermFocused) {
+        const isTerminalSafe =
+          (ctrl && e.key === "Tab") ||
+          (ctrl && shift && e.key === "ArrowRight") ||
+          (ctrl && shift && e.key === "ArrowLeft") ||
+          (ctrl && shift && e.key === "b") ||
+          (ctrl && (e.key === "=" || e.key === "+" || e.key === "-" || e.key === "0"));
+        if (!isTerminalSafe) return;
+      }
 
       if (!ctrl) return;
 


### PR DESCRIPTION
## Summary

- **Terminal-aware keybinding gating** (`useKeyBindings.ts`): replaces the blanket input-block with a two-tier check. Regular inputs are still blocked entirely. When xterm is focused, a terminal-safe subset passes through (`Ctrl+Tab`, `Ctrl+Shift+B`, `Ctrl+Shift+←/→`, font size keys) while conflicting shortcuts (`Ctrl+W`, `Ctrl+B`, `Ctrl+R`, `Ctrl+N`, etc.) are left for the terminal to handle natively.
- **Clipboard support** (`TerminalView.tsx`): `Ctrl+V` / `Ctrl+Shift+V` reads from the system clipboard and writes to the PTY (no more `\x16`). `Ctrl+Shift+C` copies the xterm selection to clipboard. `Ctrl+C` is untouched — still sends SIGINT.

## Test plan

- [ ] Open a terminal tab and focus it
- [ ] `Ctrl+Tab` → cycles to next tab
- [ ] `Ctrl+Shift+B` → toggles right panel
- [ ] `Ctrl+B` (no Shift) → does NOT toggle sidebar; terminal receives it
- [ ] `Ctrl+W` → does NOT close tab; terminal deletes word
- [ ] Copy text to system clipboard, `Ctrl+V` in terminal → clipboard text appears
- [ ] Select text in terminal, `Ctrl+Shift+C` → text lands in clipboard
- [ ] `Ctrl+C` still sends interrupt to Claude process

🤖 Generated with [Claude Code](https://claude.com/claude-code)