### PR TITLE
feat: Jira issues in the Issues tab

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,7 @@ pub fn run() {
             commands::issues::cmd_list_prs,
             commands::issues::cmd_list_issues,
             commands::issues::cmd_list_linear_issues,
+            commands::issues::cmd_list_jira_issues,
             commands::issues::cmd_get_pr_detail,
             commands::integrations::cmd_load_integration_secrets,
             commands::integrations::cmd_github_auth_status,

--- a/src/hooks/useClaudeData.ts
+++ b/src/hooks/useClaudeData.ts
@@ -210,6 +210,16 @@ export function useLinearIssues(hasKey: boolean, state = "open") {
   });
 }
 
+export function useJiraIssues(hasCredentials: boolean, baseUrl: string, email: string, state = "open") {
+  return useQuery({
+    queryKey: ["jira-issues", state, baseUrl, email, hasCredentials],
+    queryFn: () => tauri.listJiraIssues(baseUrl, email, state),
+    enabled: hasCredentials,
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
 // ---- File Watcher Hook ----
 
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -415,6 +415,10 @@ export function listLinearIssues(state = "open"): Promise<Issue[]> {
   return invoke("cmd_list_linear_issues", { state });
 }
 
+export function listJiraIssues(baseUrl: string, email: string, state = "open"): Promise<Issue[]> {
+  return invoke("cmd_list_jira_issues", { baseUrl, email, state });
+}
+
 // ---- Hook / Session Tracking Types ----
 
 export interface ActiveSubagent {


### PR DESCRIPTION
## Summary
- Adds `cmd_list_jira_issues` Rust command that calls the Jira REST API (`/rest/api/3/search`) with JQL state filtering and basic auth, mapping results to the shared `Issue` struct
- Adds `listJiraIssues` Tauri invoke wrapper in `src/lib/tauri.ts` and a `useJiraIssues` React Query hook in `useClaudeData.ts`
- Wires `useJiraIssues` into `IssueListPanel`, merging Jira issues with GitHub and Linear results sorted by date; hook is disabled when any Jira credential is missing

## Test plan
- [ ] Configure Jira in Settings (base URL, email, API token)
- [ ] Open bottom panel → Issues tab — Jira issues appear alongside GitHub/Linear with the blue Jira badge
- [ ] Switch open/closed/all filters — confirm correct JQL results from Jira
- [ ] Click ↻ refresh — all three sources refresh including Jira
- [ ] Remove Jira credentials — confirm no Jira issues appear (hook disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)