### PR TITLE
Auto-scroll terminal to bottom when re-entering a CLI tab

### DIFF
--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -172,6 +172,7 @@ export function TerminalView({ sessionId, resumeSessionId, cwd, isActive }: Term
   useEffect(() => {
     if (isActive && termRef.current) {
       termRef.current.focus();
+      termRef.current.scrollToBottom();
       const fitAddon = fitAddonRef.current;
       if (fitAddon) {
         fitAddon.fit();


### PR DESCRIPTION
When switching back to a terminal tab, the viewport could be left
at a stale scroll position. Call scrollToBottom() in the isActive
effect so users always see the latest output on tab activation.

https://claude.ai/code/session_011r41dPmP9osFMk5w7YHzuH