### PR TITLE
feat: render YAML frontmatter as styled metadata card in markdown views

### DIFF
--- a/src/components/context/ExtensionView.tsx
+++ b/src/components/context/ExtensionView.tsx
@@ -1,16 +1,18 @@
 import Markdown from "react-markdown";
 import type { SessionTab } from "@/stores/sessionStore";
+import { parseFrontmatter, FrontmatterBlock } from "@/lib/frontmatter";
 
 interface ExtensionViewProps {
   tab: SessionTab;
 }
 
 export function ExtensionView({ tab }: ExtensionViewProps) {
-  const content = tab.markdownContent ?? "";
+  const { fm, body } = parseFrontmatter(tab.markdownContent ?? "");
 
   return (
     <div className="h-full overflow-y-auto bg-[var(--color-bg-base)]">
       <div className="max-w-3xl mx-auto px-8 py-6 prose prose-invert prose-sm">
+        {fm && <FrontmatterBlock fm={fm} />}
         <Markdown
           components={{
             h1: ({ children }) => (
@@ -66,7 +68,7 @@ export function ExtensionView({ tab }: ExtensionViewProps) {
             ),
           }}
         >
-          {content}
+          {body}
         </Markdown>
       </div>
     </div>

--- a/src/components/plan/PlanEditorView.tsx
+++ b/src/components/plan/PlanEditorView.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Save, Eye, Pencil, Check } from "lucide-react";
 import { readPlan, savePlan } from "../../lib/tauri";
 import { cn } from "../../lib/utils";
+import { parseFrontmatter, FrontmatterBlock } from "../../lib/frontmatter";
 
 const MonacoEditor = lazy(() =>
   import("@monaco-editor/react").then((m) => ({ default: m.default }))
@@ -159,9 +160,11 @@ export function PlanEditorView({ filename }: PlanEditorViewProps) {
 // ── Simple inline markdown renderer ─────────────────────────────────────────
 
 function MarkdownPreview({ content }: { content: string }) {
-  const blocks = parseBlocks(content);
+  const { fm, body } = parseFrontmatter(content);
+  const blocks = parseBlocks(body);
   return (
     <div className="px-8 py-6 max-w-3xl mx-auto space-y-1.5 text-[var(--color-text-secondary)]">
+      {fm && <FrontmatterBlock fm={fm} />}
       {blocks.map((block, i) => (
         <BlockView key={i} block={block} />
       ))}

--- a/src/components/readme/ReadmeTab.tsx
+++ b/src/components/readme/ReadmeTab.tsx
@@ -5,6 +5,7 @@ import { readFile, writeFile, runClaudeInit, runReadmeGen } from "@/lib/tauri";
 import { debugLog } from "@/stores/debugStore";
 import { useUIStore } from "@/stores/uiStore";
 import { useSessionStore } from "@/stores/sessionStore";
+import { parseFrontmatter, FrontmatterBlock } from "@/lib/frontmatter";
 
 interface ReadmeTabProps {
   filePath: string;
@@ -289,7 +290,15 @@ export function ReadmeTab({ filePath, projectDir, isActive, tabId }: ReadmeTabPr
         <Pencil size={14} />
       </button>
       <div className="p-8 max-w-3xl mx-auto readme-content">
-        <Markdown components={markdownComponents}>{content ?? ""}</Markdown>
+        {(() => {
+          const { fm, body } = parseFrontmatter(content ?? "");
+          return (
+            <>
+              {fm && <FrontmatterBlock fm={fm} />}
+              <Markdown components={markdownComponents}>{body}</Markdown>
+            </>
+          );
+        })()}
       </div>
     </div>
   );

--- a/src/components/sessions/SummaryView.tsx
+++ b/src/components/sessions/SummaryView.tsx
@@ -4,6 +4,7 @@ import { readSummary } from "@/lib/tauri";
 import type { SessionTab } from "@/stores/sessionStore";
 import { useSessionStore } from "@/stores/sessionStore";
 import { useActiveProjectTabs } from "@/hooks/useActiveProjectTabs";
+import { parseFrontmatter, FrontmatterBlock } from "@/lib/frontmatter";
 
 interface SummaryViewProps {
   tab: SessionTab;
@@ -104,9 +105,11 @@ export function SummaryView({ tab, projectId }: SummaryViewProps) {
 // ── Reused inline markdown renderer (same as PlanEditorView) ─────────────────
 
 function MarkdownPreview({ content }: { content: string }) {
-  const blocks = parseBlocks(content);
+  const { fm, body } = parseFrontmatter(content);
+  const blocks = parseBlocks(body);
   return (
     <div className="px-8 py-6 max-w-3xl mx-auto space-y-1.5 text-[var(--color-text-secondary)]">
+      {fm && <FrontmatterBlock fm={fm} />}
       {blocks.map((block, i) => (
         <BlockView key={i} block={block} />
       ))}

--- a/src/lib/frontmatter.tsx
+++ b/src/lib/frontmatter.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+
+type FmValue = string | boolean | string[];
+
+export interface ParsedFrontmatter {
+  fm: Record<string, FmValue> | null;
+  body: string;
+}
+
+export function parseFrontmatter(content: string): ParsedFrontmatter {
+  // Normalize line endings so \r\n files work the same as \n files
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const trimmed = normalized.replace(/^\s*/, "");
+
+  // Opening --- must be on its own line
+  if (!trimmed.startsWith("---\n") && trimmed !== "---") {
+    return { fm: null, body: content };
+  }
+
+  const afterOpen = trimmed.slice(4); // skip "---\n"
+  // Find closing --- on its own line
+  const closeMatch = afterOpen.match(/\n---[ \t]*(\n|$)/);
+  if (!closeMatch || closeMatch.index === undefined) {
+    return { fm: null, body: content };
+  }
+
+  const yamlText = afterOpen.slice(0, closeMatch.index);
+  const body = afterOpen.slice(closeMatch.index + closeMatch[0].length);
+
+  const fm: Record<string, FmValue> = {};
+  const lines = yamlText.split("\n");
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const keyMatch = line.match(/^(\w[\w-]*):\s*(.*)/);
+    if (!keyMatch) { i++; continue; }
+
+    const key = keyMatch[1];
+    const rest = keyMatch[2].trim();
+
+    // Inline array: [a, b, c]
+    if (rest.startsWith("[") && rest.endsWith("]")) {
+      const items = rest.slice(1, -1).split(",").map((s) => s.trim()).filter(Boolean);
+      fm[key] = items;
+      i++;
+      continue;
+    }
+
+    // Boolean
+    if (rest === "true") { fm[key] = true; i++; continue; }
+    if (rest === "false") { fm[key] = false; i++; continue; }
+
+    // Empty value — might be followed by bullet list
+    if (rest === "") {
+      const listItems: string[] = [];
+      i++;
+      while (i < lines.length && /^\s*-\s/.test(lines[i])) {
+        listItems.push(lines[i].replace(/^\s*-\s*/, "").trim());
+        i++;
+      }
+      fm[key] = listItems.length > 0 ? listItems : "";
+      continue;
+    }
+
+    fm[key] = rest;
+    i++;
+  }
+
+  if (Object.keys(fm).length === 0) {
+    return { fm: null, body: content };
+  }
+
+  return { fm, body };
+}
+
+// ── FrontmatterBlock component ────────────────────────────────────────────────
+
+interface FrontmatterBlockProps {
+  fm: Record<string, FmValue>;
+}
+
+export function FrontmatterBlock({ fm }: FrontmatterBlockProps) {
+  const entries = Object.entries(fm);
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-[var(--color-border-muted)] border-l-2 border-l-[var(--color-accent-primary)] bg-[var(--color-bg-raised)] px-4 py-3 mb-6">
+      <div
+        className="mb-2 font-mono"
+        style={{ fontSize: "10px", color: "var(--color-text-muted)" }}
+      >
+        frontmatter
+      </div>
+      <div className="grid gap-x-4 gap-y-1" style={{ gridTemplateColumns: "auto 1fr" }}>
+        {entries.map(([key, value]) => (
+          <React.Fragment key={key}>
+            <span
+              className="font-mono self-start pt-0.5"
+              style={{ fontSize: "10px", color: "var(--color-text-muted)" }}
+            >
+              {key}
+            </span>
+            <FmValueDisplay value={value} />
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FmValueDisplay({ value }: { value: FmValue }) {
+  if (typeof value === "boolean") {
+    return (
+      <span
+        className="text-xs"
+        style={{ color: value ? "var(--color-status-success)" : "var(--color-text-muted)" }}
+      >
+        {value ? "true" : "false"}
+      </span>
+    );
+  }
+
+  if (Array.isArray(value)) {
+    return (
+      <div className="flex flex-wrap gap-1">
+        {value.map((item, i) => (
+          <span
+            key={i}
+            className="text-xs px-1.5 py-0.5 rounded border"
+            style={{
+              backgroundColor: "var(--color-bg-surface)",
+              borderColor: "var(--color-border-muted)",
+              color: "var(--color-text-secondary)",
+            }}
+          >
+            {item}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <span className="text-xs" style={{ color: "var(--color-text-secondary)" }}>
+      {value}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `src/lib/frontmatter.tsx` with `parseFrontmatter()` (handles `\r\n` line endings, strict `---\n` opener) and `FrontmatterBlock` component (left-accented card, 2-col grid, inline tags for arrays, coloured booleans)
- Apply to **ExtensionView** (skills/agents/commands in Context panel), **ReadmeTab** (README/CLAUDE.md view mode), **PlanEditorView** (plan preview), and **SummaryView** (session summary preview)
- Edit mode in all views is unaffected — raw frontmatter still editable as plain text

## Test plan

- [ ] Open a skill or agent in the Context panel — frontmatter shows as styled card, body renders as markdown
- [ ] Open a plan file with frontmatter in preview mode — metadata card appears above content
- [ ] Open a README or CLAUDE.md with frontmatter — card renders in view mode, edit mode still shows raw text
- [ ] Open a file with no frontmatter — no card, content unchanged
- [ ] Test a file saved with Windows line endings (`\r\n`) — parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)