### PR TITLE
feat: extend activity bars to full window height

### DIFF
--- a/src/components/layout/IDELayout.tsx
+++ b/src/components/layout/IDELayout.tsx
@@ -22,12 +22,12 @@ function IDELayoutComponent() {
   ];
 
   return (
-    <PanelGroup direction="vertical" className="flex-1 overflow-hidden p-1.5 gap-1.5 bg-bg-base">
-      {/* Top section: activity bars + sidebar + main + right panel */}
-      <Panel minSize={30}>
-        <div className="flex h-full overflow-hidden gap-1.5">
-          <ActivityBar />
+    <div className="flex flex-1 overflow-hidden p-1.5 gap-1.5 bg-bg-base">
+      <ActivityBar />
 
+      <PanelGroup direction="vertical" className="flex-1 overflow-hidden gap-1.5">
+        {/* Top section: sidebar + main + right panel */}
+        <Panel minSize={30}>
           <PanelGroup direction="horizontal" className="flex-1 gap-1.5">
             {sidebarOpen && (
               <>
@@ -70,23 +70,23 @@ function IDELayoutComponent() {
               </>
             )}
           </PanelGroup>
+        </Panel>
 
-          <RightActivityBar />
-        </div>
-      </Panel>
+        {/* Bottom panel — sits between the two activity bars */}
+        {bottomPanelOpen && (
+          <>
+            <PanelResizeHandle className="h-1 rounded-full hover:bg-accent-primary/60 cursor-row-resize transition-all duration-200" />
+            <Panel defaultSize={25} minSize={10} maxSize={60}>
+              <div className="h-full rounded-xl overflow-hidden bg-bg-surface" style={{ boxShadow: "0 1px 3px rgba(0,0,0,0.2)" }}>
+                <BottomPanel />
+              </div>
+            </Panel>
+          </>
+        )}
+      </PanelGroup>
 
-      {/* Full-width bottom panel */}
-      {bottomPanelOpen && (
-        <>
-          <PanelResizeHandle className="h-1 rounded-full hover:bg-accent-primary/60 cursor-row-resize transition-all duration-200" />
-          <Panel defaultSize={25} minSize={10} maxSize={60}>
-            <div className="h-full rounded-xl overflow-hidden bg-bg-surface" style={{ boxShadow: "0 1px 3px rgba(0,0,0,0.2)" }}>
-              <BottomPanel />
-            </div>
-          </Panel>
-        </>
-      )}
-    </PanelGroup>
+      <RightActivityBar />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Move `<ActivityBar />` and `<RightActivityBar />` outside the vertical `PanelGroup` so they span the full IDE height
- Replace the outer `PanelGroup direction="vertical"` wrapper with a plain flex `div`
- The bottom panel now sits only between the two activity bars instead of spanning the full window width

## Test plan

- [ ] Open the bottom panel — confirm it stops at the left activity bar's right edge and the right activity bar's left edge
- [ ] Resize the bottom panel vertically — confirm both activity bars remain full height throughout
- [ ] Toggle sidebar and right panel open/closed — confirm layout still responds correctly
- [ ] Confirm the vertical resize handle is still functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)