### PR TITLE
feat: notes system, smart auto-attach, and native notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,14 +49,14 @@ npm run tauri build      # release build
 | Area | Files | Purpose |
 |------|-------|---------|
 | Entry | `src/main.tsx`, `src/App.tsx` | No StrictMode; ErrorBoundary wraps IDEShell; loads settings + projects on mount |
-| Stores | `src/stores/uiStore.ts` | Panel visibility, sidebar/right/bottom tab state, neural field, debug panel |
+| Stores | `src/stores/uiStore.ts` | Panel visibility, sidebar/right/bottom tab state, neural field, debug panel, `pendingNoteRef` for editor→notes handoff |
 | | `src/stores/sessionStore.ts` | Per-project tabs (open/close/resume), subagent tracking, plan links |
 | | `src/stores/projectsStore.ts` | Multi-project management, active project, `pathToProjectId()` encoding |
 | | `src/stores/settingsStore.ts` | Font, GitHub/Linear/Jira config; secrets via keyring, rest via `settings.json` |
 | | `src/stores/notificationStore.ts` | Claude question notifications (per-tab, read/unread) |
 | | `src/stores/outputStore.ts` | Output panel messages (git actions, operations log) |
 | | `src/stores/debugStore.ts` | Dev-only debug log (max 500 entries) |
-| Hooks | `src/hooks/useClaudeData.ts` | React Query hooks for all data (sessions, teams, tasks, inbox, git, PRs, issues); `useClaudeWatcher()` listens for Tauri events |
+| Hooks | `src/hooks/useClaudeData.ts` | React Query hooks for all data (sessions, teams, tasks, inbox, git, PRs, issues, notes); `useClaudeWatcher()` listens for Tauri events |
 | | `src/hooks/useKeyBindings.ts` | Global keyboard shortcuts |
 | | `src/hooks/useGitAction.ts` | Wraps async git ops with output panel logging |
 | | `src/hooks/useActiveProjectTabs.ts` | Derives tabs/activeTab for current project |
@@ -83,9 +83,10 @@ npm run tauri build      # release build
 | | `commands/issues.rs` | List GitHub PRs, GitHub issues, and Linear issues |
 | | `commands/summaries.rs` | Load/read session completion summaries |
 | | `commands/files.rs` | Directory listing for file browser |
-| Data layer | `data/` module | File I/O + parsing for each domain: `sessions`, `transcripts`, `teams`, `tasks`, `inboxes`, `todos`, `plans`, `summaries`, `projects`, `git`, `hook_state`, `watcher_state`, `path_encoding` |
-| Models | `models/` module | Serde structs: `session`, `transcript`, `team`, `task`, `inbox`, `todo`, `plan`, `summary`, `git`, `hook_event` |
-| Watcher | `watcher/claude_watcher.rs` | Watches `~/.claude/` dirs (teams, tasks, projects, todos, plans, theassociate); emits Tauri events on file changes; parses `hook-events.jsonl` for session/subagent lifecycle |
+| | `commands/notes.rs` | Load/save/delete notes from `~/.claude/notes/` (global) and `~/.claude/projects/{encoded}/notes/` (per-project) |
+| Data layer | `data/` module | File I/O + parsing for each domain: `sessions`, `transcripts`, `teams`, `tasks`, `inboxes`, `todos`, `plans`, `notes`, `summaries`, `projects`, `git`, `hook_state`, `watcher_state`, `path_encoding` |
+| Models | `models/` module | Serde structs: `session`, `transcript`, `team`, `task`, `inbox`, `todo`, `plan`, `note`, `summary`, `git`, `hook_event` |
+| Watcher | `watcher/claude_watcher.rs` | Watches `~/.claude/` dirs (teams, tasks, projects, todos, plans, notes, theassociate); emits Tauri events on file changes; parses `hook-events.jsonl` for session/subagent lifecycle |
 
 ## Component areas
 
@@ -104,8 +105,9 @@ npm run tauri build      # release build
 | Notifications | `components/notifications/` | Claude question notification badges |
 | Settings | `components/settings/` | Settings tab (font, integrations) |
 | Debug | `components/debug/` | Dev-only debug panel (Ctrl+Shift+D) |
-| Files | `components/files/` | File browser sidebar view |
+| Files | `components/files/` | File browser sidebar view; `FileEditorTab` has Monaco selection → "Add to note" button |
 | README | `components/readme/` | README viewer/editor tab |
+| Notes | `components/notes/` | `NotesPanel` (orchestrator), `NotesList` (scoped list), `NoteEditor` (markdown editor + file refs) |
 
 ## Critical gotchas (details in docs)
 

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,0 +1,241 @@
+# Vylos
+**Next-Generation Agentic Development Infrastructure**
+
+---
+
+## 1. Name
+
+**Vylos**  
+Pronunciation: **VY-los** (/ˈvaɪ.lɒs/)
+
+Two syllables. Sharp. Engineered. Modern.
+
+The name is abstract and ownable. Its meaning is defined by the product.
+
+---
+
+## 2. Core Identity
+
+Vylos is a **contained synthetic intelligence system for parallel software development**.
+
+It is not:
+- A chatbot wrapper  
+- An AI editor  
+- A dashboard  
+
+It is:
+- Infrastructure  
+- A coordination layer  
+- A high-tech digital organism  
+- A controlled emergent system  
+
+Vylos orchestrates parallel Claude sessions and multi-project workflows as cellular units within a contained intelligence fabric.
+
+---
+
+## 3. Conceptual Metaphor
+
+### High-Tech Cellular System
+
+Vylos is a **synthetic organism engineered for code**.
+
+Mapping:
+
+- Cells → isolated execution sessions  
+- Membranes → project boundaries  
+- DNA → repo state + context memory  
+- Signals → cross-project notifications  
+- Clusters → related workstreams  
+- Replication → spawning parallel agents  
+- Mutation → branching strategies  
+- Containment → bounded AI autonomy  
+
+It is alive — but controlled.  
+Emergent — but engineered.
+
+---
+
+## 4. Emotional Tone
+
+Chosen Direction:  
+**Next-generation dev infrastructure + controlled AI containment system**
+
+Emotional qualities:
+
+- Slightly ominous intelligence  
+- Engineered precision  
+- Contained power  
+- Emerging patterns  
+- Quiet dominance  
+
+It feels like classified technology.  
+But elegant.
+
+---
+
+## 5. Positioning
+
+### Category
+
+**AI-Native Orchestration Infrastructure**
+
+Competitor Contrast:
+
+VS Code → extensible IDE  
+Cursor → AI editor  
+Claude CLI → terminal agent  
+
+**Vylos → Synthetic coordination layer for parallel agentic development**
+
+---
+
+## 6. Messaging Framework
+
+### Primary Positioning Line
+
+**Vylos**  
+Parallel intelligence, contained.
+
+---
+
+### Alternative Positioning Lines
+
+Vylos  
+Infrastructure for emergent code.
+
+Vylos  
+Synthetic coordination for AI-native development.
+
+Vylos  
+Engineered emergence.
+
+Vylos  
+Control the emergence.
+
+---
+
+## 7. Product Language System
+
+Avoid:
+- Open tab  
+- Run agent  
+- New session  
+- Workspace  
+
+Use:
+
+- Initialize Cell  
+- Fork Instance  
+- Isolate Context  
+- Signal Cluster  
+- Stabilize Network  
+- Archive Dormant Cell  
+- Promote Mutation  
+- Contain Drift  
+- Sequence Memory  
+
+Language reinforces category.
+
+---
+
+## 8. Visual Identity Direction
+
+### Core Palette
+
+- Matte graphite / near-black base  
+- Deep violet energy veins  
+- Electric cyan signal pulses  
+- Subtle glass membrane highlights  
+
+---
+
+### Visual Motifs
+
+- Circular cellular nodes  
+- Membrane outlines  
+- Signal arcs between clusters  
+- Soft pulsing motion  
+- Heat-map energy gradients  
+- Micro hex or lattice background textures  
+
+No playful gradients.  
+No soft pastel biotech aesthetics.  
+No chaotic animation.
+
+Everything feels sealed. Controlled. Active.
+
+---
+
+## 9. Interface Philosophy
+
+The UI should feel like:
+
+- A containment chamber for intelligence  
+- A living substrate under glass  
+- A system that occasionally surfaces emergent insight  
+
+Not flashy.  
+Not cluttered.  
+Not gamified.
+
+Subtle movement implies life.
+
+---
+
+## 10. Experience Principles
+
+1. Parallel by default  
+2. Isolation with optional signaling  
+3. Emergence surfaced, not forced  
+4. Intelligence contained  
+5. Infrastructure, not feature  
+
+---
+
+## 11. Personality Traits
+
+Vylos is:
+
+- Precise  
+- Composed  
+- Advanced  
+- Slightly mysterious  
+- Controlled  
+- Scalable  
+
+It is never:
+
+- Playful  
+- Cute  
+- Overly conversational  
+- Chaotic  
+
+---
+
+## 12. Strategic Future Extensions
+
+Vylos Core  
+Vylos Cluster  
+Vylos Cloud  
+Vylos Sequence  
+Vylos Containment  
+
+The name scales across infrastructure layers.
+
+---
+
+## 13. Brand Manifesto
+
+Vylos is not an AI assistant.  
+It is a synthetic coordination system.
+
+It isolates intelligence into cells.  
+It allows them to signal.  
+It permits emergence — within bounds.
+
+You are not prompting.  
+You are cultivating structured intelligence.
+
+Parallel systems.  
+Contained power.  
+Engineered evolution.

--- a/docs/data-formats.md
+++ b/docs/data-formats.md
@@ -358,3 +358,44 @@ When a summary is saved, a `session-summary` event is emitted:
 ```
 
 The frontend listens for this event and invalidates the `["summaries"]` query cache.
+
+## Notes
+
+Notes are stored as individual JSON files, one per note.
+
+```
+~/.claude/notes/{id}.json                              <-- global notes
+~/.claude/projects/{encoded-path}/notes/{id}.json     <-- per-project notes
+```
+
+### Note schema
+
+```json
+{
+  "id": "m5xj2-ab3cd",
+  "title": "Auth bug investigation",
+  "content": "## Findings\n\nThe token is...",
+  "projectPath": "C:\\dev\\myapp",
+  "fileRefs": [
+    {
+      "id": "m5xj3-ef4gh",
+      "filePath": "C:\\dev\\myapp\\src\\auth.ts",
+      "lineStart": 42,
+      "lineEnd": 55,
+      "quote": "const token = jwt.sign(..."
+    }
+  ],
+  "created": 1700000000000,
+  "modified": 1700000001234
+}
+```
+
+- `projectPath: null` → global note, stored in `~/.claude/notes/`
+- `projectPath: "C:\\dev\\..."` → project note, stored in `~/.claude/projects/{encoded}/notes/`
+- `created`/`modified` are millisecond timestamps
+- `fileRefs` are optional line-anchored code snippets captured from the Monaco editor
+
+### File watcher events
+
+- `notes-changed` — emitted when any `~/.claude/notes/*.json` changes or when any `~/.claude/projects/*/notes/*.json` changes
+- Frontend invalidates the `["notes"]` React Query cache on this event

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.0.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-fs": "^2",
+        "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-shell": "^2",
         "@tauri-apps/plugin-store": "^2",
         "@xterm/addon-fit": "^0.10.0",
@@ -70,6 +71,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2168,6 +2170,15 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tauri-apps/plugin-notification": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
+      "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-shell": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
@@ -2284,6 +2295,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2294,6 +2306,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2303,8 +2316,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2370,7 +2382,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
@@ -2427,6 +2440,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2633,7 +2647,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -3246,7 +3259,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3930,6 +3942,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3981,6 +3994,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3990,6 +4004,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4548,6 +4563,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query": "^5.0.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-fs": "^2",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-shell": "^2",
     "@tauri-apps/plugin-store": "^2",
     "@xterm/addon-fit": "^0.10.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2213,6 +2213,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65fd3f75411f4725061682ed91f131946e912859d0044d39c4ec0aac818d7621"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2439,20 @@ dependencies = [
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus 5.13.2",
 ]
 
 [[package]]
@@ -3047,7 +3073,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3216,6 +3242,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -3264,6 +3299,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3284,6 +3329,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3299,6 +3354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4431,6 +4495,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4591,6 +4674,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4641,10 +4736,12 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-fs",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-store",
  "tokio",
+ "windows",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-store = "2"
+tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
@@ -30,3 +31,10 @@ reqwest = { version = "0.12", features = ["json"] }
 open = "5"
 keyring = "3"
 rfd = "0.14"
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_UI_Shell",
+    "Win32_UI_Shell_PropertiesSystem",
+] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,10 @@
     "core:window:allow-minimize",
     "core:window:allow-maximize",
     "core:window:allow-unmaximize",
-    "core:window:allow-close"
+    "core:window:allow-close",
+    "notification:default",
+    "notification:allow-is-permission-granted",
+    "notification:allow-request-permission",
+    "notification:allow-notify"
   ]
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod hooks;
 pub mod inbox;
 pub mod integrations;
 pub mod issues;
+pub mod notes;
 pub mod plans;
 pub mod projects;
 pub mod pty;

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -1,0 +1,44 @@
+use crate::data::notes;
+use crate::models::note::Note;
+use std::path::PathBuf;
+
+fn get_claude_home() -> Result<PathBuf, String> {
+    let home = std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .map_err(|_| "Neither USERPROFILE nor HOME environment variable is set".to_string())?;
+    if home.is_empty() {
+        return Err("Home directory environment variable is empty".to_string());
+    }
+    Ok(PathBuf::from(home).join(".claude"))
+}
+
+#[tauri::command]
+pub async fn cmd_load_global_notes() -> Result<Vec<Note>, String> {
+    let claude_home = get_claude_home()?;
+    notes::load_global_notes(&claude_home).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn cmd_load_project_notes(project_path: String) -> Result<Vec<Note>, String> {
+    let claude_home = get_claude_home()?;
+    let encoded = crate::data::path_encoding::encode_project_path(
+        &std::path::PathBuf::from(&project_path),
+    );
+    notes::load_project_notes(&claude_home, &encoded).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn cmd_save_note(note: Note) -> Result<(), String> {
+    let claude_home = get_claude_home()?;
+    notes::save_note(&claude_home, &note).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn cmd_delete_note(
+    note_id: String,
+    encoded_project_id: Option<String>,
+) -> Result<(), String> {
+    let claude_home = get_claude_home()?;
+    notes::delete_note(&claude_home, &note_id, encoded_project_id.as_deref())
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/data/mod.rs
+++ b/src-tauri/src/data/mod.rs
@@ -2,6 +2,7 @@ pub mod claude_config;
 pub mod git;
 pub mod hook_state;
 pub mod inboxes;
+pub mod notes;
 pub mod path_encoding;
 pub mod plans;
 pub mod projects;

--- a/src-tauri/src/data/notes.rs
+++ b/src-tauri/src/data/notes.rs
@@ -1,0 +1,84 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::models::note::Note;
+
+/// Load all notes from a directory, sorted by `modified` descending.
+pub fn load_notes_from_dir(dir: &Path) -> Result<Vec<Note>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut notes = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let text = match std::fs::read_to_string(&path) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let note: Note = match serde_json::from_str(&text) {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        notes.push(note);
+    }
+
+    notes.sort_by(|a, b| b.modified.cmp(&a.modified));
+    Ok(notes)
+}
+
+/// Load global notes from `~/.claude/notes/`.
+pub fn load_global_notes(claude_home: &Path) -> Result<Vec<Note>> {
+    let notes_dir = claude_home.join("notes");
+    load_notes_from_dir(&notes_dir)
+}
+
+/// Load project notes from `~/.claude/projects/{encoded_id}/notes/`.
+pub fn load_project_notes(claude_home: &Path, encoded_id: &str) -> Result<Vec<Note>> {
+    let notes_dir = claude_home.join("projects").join(encoded_id).join("notes");
+    load_notes_from_dir(&notes_dir)
+}
+
+/// Save a note to the appropriate directory based on `note.project_path`.
+pub fn save_note(claude_home: &Path, note: &Note) -> Result<()> {
+    let dir = match &note.project_path {
+        None => claude_home.join("notes"),
+        Some(project_path) => {
+            let encoded = crate::data::path_encoding::encode_project_path(
+                &std::path::PathBuf::from(project_path),
+            );
+            claude_home.join("projects").join(encoded).join("notes")
+        }
+    };
+    std::fs::create_dir_all(&dir)?;
+    let file_path = dir.join(format!("{}.json", note.id));
+    let text = serde_json::to_string_pretty(note)?;
+    std::fs::write(&file_path, text)?;
+    Ok(())
+}
+
+/// Delete a note by ID from the appropriate directory.
+pub fn delete_note(
+    claude_home: &Path,
+    note_id: &str,
+    encoded_project_id: Option<&str>,
+) -> Result<()> {
+    let dir = match encoded_project_id {
+        None => claude_home.join("notes"),
+        Some(enc) => claude_home.join("projects").join(enc).join("notes"),
+    };
+    let file_path = dir.join(format!("{}.json", note_id));
+    // Guard against path traversal
+    if !file_path.starts_with(&dir) {
+        return Err(anyhow::anyhow!("Invalid note path"));
+    }
+    if file_path.exists() {
+        std::fs::remove_file(&file_path)?;
+    }
+    Ok(())
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -2,6 +2,7 @@ pub mod claude_config;
 pub mod git;
 pub mod hook_event;
 pub mod inbox;
+pub mod note;
 pub mod plan;
 pub mod session;
 pub mod summary;

--- a/src-tauri/src/models/note.rs
+++ b/src-tauri/src/models/note.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileRef {
+    pub id: String,
+    pub file_path: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub quote: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Note {
+    pub id: String,
+    pub title: String,
+    pub content: String,
+    pub project_path: Option<String>, // None = global
+    pub file_refs: Vec<FileRef>,
+    pub created: u64, // ms timestamp
+    pub modified: u64,
+}

--- a/src-tauri/src/startup.rs
+++ b/src-tauri/src/startup.rs
@@ -1,0 +1,82 @@
+/// Creates a Start Menu shortcut for the app with `System.AppUserModel.ID` set
+/// so that Windows toast notifications show as "The Associate Studio" rather
+/// than PowerShell. Idempotent — silently skips if the shortcut already exists.
+pub fn ensure_start_menu_shortcut() {
+    #[cfg(target_os = "windows")]
+    unsafe {
+        if let Err(e) = create_shortcut() {
+            eprintln!("[ide] start menu shortcut: {e:?}");
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn create_shortcut() -> windows::core::Result<()> {
+    use windows::{
+        core::{Interface, GUID, HSTRING},
+        Win32::System::Com::{
+            CoCreateInstance, CoInitializeEx, CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED,
+            IPersistFile, StructuredStorage::PROPVARIANT,
+        },
+        Win32::Foundation::PROPERTYKEY,
+        Win32::UI::Shell::{
+            IShellLinkW, ShellLink,
+            PropertiesSystem::IPropertyStore,
+        },
+    };
+
+    let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+
+    // Resolve %APPDATA%\Microsoft\Windows\Start Menu\Programs\
+    let Ok(appdata) = std::env::var("APPDATA") else {
+        return Ok(());
+    };
+    let shortcut_path = format!(
+        "{}\\Microsoft\\Windows\\Start Menu\\Programs\\The Associate Studio.lnk",
+        appdata
+    );
+
+    // Already created on a previous launch — nothing to do.
+    if std::path::Path::new(&shortcut_path).exists() {
+        return Ok(());
+    }
+
+    let Ok(exe) = std::env::current_exe() else {
+        return Ok(());
+    };
+
+    // Create an IShellLink pointing at the current executable.
+    let link: IShellLinkW = CoCreateInstance(&ShellLink, None, CLSCTX_INPROC_SERVER)?;
+    link.SetPath(&HSTRING::from(exe.to_string_lossy().as_ref()))?;
+
+    // Set PKEY_AppUserModel_ID = {9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}, pid=5
+    let pkey = PROPERTYKEY {
+        fmtid: GUID {
+            data1: 0x9F4C2855,
+            data2: 0x9F79,
+            data3: 0x4B39,
+            data4: [0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3],
+        },
+        pid: 5,
+    };
+
+    // Build a VT_LPWSTR (31) PROPVARIANT at the byte level.
+    // 64-bit layout: [0..2] vt=31, [2..8] reserved, [8..16] pwszVal pointer.
+    let mut aumid: Vec<u16> = "com.keith.the-associate-studio\0"
+        .encode_utf16()
+        .collect();
+    let mut pv = PROPVARIANT::default();
+    let base = std::ptr::addr_of_mut!(pv) as *mut u8;
+    *(base as *mut u16) = 31u16; // VT_LPWSTR
+    *(base.add(8) as *mut *mut u16) = aumid.as_mut_ptr();
+
+    let store: IPropertyStore = link.cast()?;
+    store.SetValue(&pkey, &pv)?;
+    store.Commit()?;
+
+    // Persist the .lnk file.
+    let persist: IPersistFile = link.cast()?;
+    persist.Save(&HSTRING::from(shortcut_path.as_str()), true)?;
+
+    Ok(())
+}

--- a/src-tauri/src/watcher/claude_watcher.rs
+++ b/src-tauri/src/watcher/claude_watcher.rs
@@ -63,6 +63,7 @@ pub fn start_claude_watcher(app_handle: tauri::AppHandle) {
     let projects_dir = claude_home.join("projects");
     let todos_dir = claude_home.join("todos");
     let plans_dir = claude_home.join("plans");
+    let notes_dir = claude_home.join("notes");
 
     watcher
         .watch(&teams_dir, RecursiveMode::Recursive)
@@ -78,6 +79,9 @@ pub fn start_claude_watcher(app_handle: tauri::AppHandle) {
         .ok();
     watcher
         .watch(&plans_dir, RecursiveMode::NonRecursive)
+        .ok();
+    watcher
+        .watch(&notes_dir, RecursiveMode::NonRecursive)
         .ok();
 
     let ide_dir = claude_home.join("theassociate");
@@ -130,6 +134,12 @@ pub fn start_claude_watcher(app_handle: tauri::AppHandle) {
                         let _ = app_handle.emit("todos-changed", &path_str);
                     } else if is_claude_child(path, "plans") {
                         let _ = app_handle.emit("plans-changed", &path_str);
+                    } else if is_claude_child(path, "notes") {
+                        let _ = app_handle.emit("notes-changed", &path_str);
+                    } else if is_claude_child(path, "projects")
+                        && (path_str.contains("/notes/") || path_str.contains("\\notes\\"))
+                    {
+                        let _ = app_handle.emit("notes-changed", &path_str);
                     } else if path_str.contains("hook-events.jsonl") {
                         use std::io::{Read, Seek, SeekFrom};
                         if let Ok(mut file) = std::fs::File::open(path) {

--- a/src/components/issues/IssueListPanel.tsx
+++ b/src/components/issues/IssueListPanel.tsx
@@ -19,7 +19,7 @@ export function IssueListPanel() {
 
   const { data: ghIssues, isLoading: ghLoading, error: ghError, refetch: ghRefetch } = useIssues(activeProjectDir, state);
   const { data: linearIssues, isLoading: linearLoading, refetch: linearRefetch } = useLinearIssues(!!linearApiKey, state);
-  const { data: jiraIssues, isLoading: jiraLoading, refetch: jiraRefetch } = useJiraIssues(hasJira, jiraBaseUrl, jiraEmail, state);
+  const { data: jiraIssues, isLoading: jiraLoading, error: jiraError, refetch: jiraRefetch } = useJiraIssues(hasJira, jiraBaseUrl, jiraEmail, state);
 
   const issues = useMemo(() => {
     const all = [...(ghIssues ?? []), ...(linearIssues ?? []), ...(jiraIssues ?? [])];
@@ -76,7 +76,12 @@ export function IssueListPanel() {
             {ghError instanceof Error ? ghError.message : "Failed to load GitHub issues"}
           </div>
         )}
-        {!isLoading && !ghError && issues.length === 0 && (
+        {!isLoading && jiraError && (
+          <div className="p-3 text-xs text-[var(--color-status-error)]">
+            Jira: {jiraError instanceof Error ? jiraError.message : String(jiraError)}
+          </div>
+        )}
+        {!isLoading && !ghError && !jiraError && issues.length === 0 && (
           <div className="p-3 text-xs text-[var(--color-text-muted)] text-center">
             No {state === "all" ? "" : state} issues
           </div>

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -4,6 +4,7 @@ import { ContextPanel } from "@/components/context/ContextPanel";
 import { TeamsRightPanel } from "@/components/context/TeamsRightPanel";
 import { PlansPanel } from "@/components/context/PlansPanel";
 import { DocsSection } from "@/components/context/DocsSection";
+import { NotesPanel } from "@/components/notes/NotesPanel";
 import { useProjectsStore } from "@/stores/projectsStore";
 
 function DocsTabPanel() {
@@ -39,6 +40,7 @@ function RightPanelComponent() {
         {activeTab === "teams" && <TeamsRightPanel />}
         {activeTab === "plans" && <PlansPanel />}
         {activeTab === "docs" && <DocsTabPanel />}
+        {activeTab === "notes" && <NotesPanel />}
       </div>
     </div>
   );

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -1,0 +1,173 @@
+import { useState, useEffect, useRef } from "react";
+import { ArrowLeft, Save, Trash2, ExternalLink, ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Note, FileRef } from "@/lib/tauri";
+import { useSessionStore } from "@/stores/sessionStore";
+import { useProjectsStore } from "@/stores/projectsStore";
+import { useUIStore } from "@/stores/uiStore";
+
+interface NoteEditorProps {
+  note: Note;
+  onBack: () => void;
+  onSave: (note: Note) => void;
+  onDelete: (note: Note) => void;
+}
+
+function FileRefItem({ ref: fileRef }: { ref: FileRef }) {
+  const openTab = useSessionStore((s) => s.openTab);
+  const activeProject = useProjectsStore((s) =>
+    s.projects.find((p) => p.id === s.activeProjectId)
+  );
+  const activeProjectId = useProjectsStore((s) => s.activeProjectId);
+
+  const fileName = fileRef.filePath.replace(/\\/g, "/").split("/").pop() ?? fileRef.filePath;
+
+  const handleGoToFile = () => {
+    if (!activeProjectId) return;
+    const tabId = `file:${fileRef.filePath}`;
+    openTab(
+      {
+        id: tabId,
+        type: "file",
+        title: fileName,
+        filePath: fileRef.filePath,
+        projectDir: activeProject?.path ?? "",
+      },
+      activeProjectId
+    );
+  };
+
+  return (
+    <div
+      className="flex items-start gap-2 px-3 py-2 rounded-lg bg-bg-surface border border-border-muted cursor-pointer hover:border-[var(--color-accent-primary)] transition-colors duration-200"
+      onClick={handleGoToFile}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] font-mono text-[var(--color-accent-secondary)] truncate">
+            {fileRef.lineStart === 0
+              ? `${fileName} (whole file)`
+              : `${fileName}:${fileRef.lineStart}${fileRef.lineEnd !== fileRef.lineStart ? `–${fileRef.lineEnd}` : ""}`}
+          </span>
+        </div>
+        {fileRef.quote && (
+          <pre className="text-[10px] text-text-muted mt-1 whitespace-pre-wrap font-mono line-clamp-3 bg-bg-raised px-2 py-1 rounded border border-border-muted">
+            {fileRef.quote}
+          </pre>
+        )}
+      </div>
+      <ExternalLink size={10} className="text-text-muted shrink-0 mt-0.5" />
+    </div>
+  );
+}
+
+export function NoteEditor({ note, onBack, onSave, onDelete }: NoteEditorProps) {
+  const [title, setTitle] = useState(note.title);
+  const [content, setContent] = useState(note.content);
+  const [refsOpen, setRefsOpen] = useState(true);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const setPendingAttachToNoteId = useUIStore((s) => s.setPendingAttachToNoteId);
+
+  // Reset when note changes and focus textarea
+  useEffect(() => {
+    setTitle(note.title);
+    setContent(note.content);
+    setTimeout(() => textareaRef.current?.focus(), 50);
+  }, [note.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isDirty = title !== note.title || content !== note.content;
+
+  const handleSave = () => {
+    if (!isDirty) return;
+    onSave({
+      ...note,
+      title,
+      content,
+      modified: Date.now(),
+    });
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Toolbar */}
+      <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border-muted shrink-0">
+        <button
+          onClick={onBack}
+          title="Back to list"
+          className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-bg-surface transition-all duration-200"
+        >
+          <ArrowLeft size={12} />
+        </button>
+        <div className="flex-1" />
+        <button
+          onClick={handleSave}
+          disabled={!isDirty}
+          title="Save"
+          className={cn(
+            "flex items-center gap-1 px-2 py-1 rounded text-[10px] transition-all duration-200",
+            isDirty
+              ? "bg-[var(--color-accent-primary)] text-white hover:opacity-90"
+              : "text-text-muted cursor-default"
+          )}
+        >
+          <Save size={10} />
+          Save
+        </button>
+        <button
+          onClick={() => onDelete(note)}
+          title="Delete note"
+          className="p-1 rounded text-text-muted hover:text-[var(--color-status-error)] hover:bg-bg-surface transition-all duration-200"
+        >
+          <Trash2 size={12} />
+        </button>
+      </div>
+
+      {/* Title */}
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Note title…"
+        className="w-full bg-transparent border-b border-border-muted px-3 py-2 text-sm font-semibold text-text-primary placeholder:text-text-muted focus:outline-none focus:border-[var(--color-accent-primary)] transition-colors duration-200 shrink-0"
+      />
+
+      {/* Body */}
+      <div className="flex-1 overflow-hidden flex flex-col min-h-0">
+        <textarea
+          ref={textareaRef}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Write your note in markdown…"
+          className="flex-1 w-full bg-transparent px-3 py-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:outline-none resize-none"
+          spellCheck={false}
+        />
+      </div>
+
+      {/* File refs section — always visible */}
+      <div className="border-t border-border-muted shrink-0">
+        <div className="flex items-center w-full px-3 py-1.5">
+          <button
+            onClick={() => setRefsOpen(!refsOpen)}
+            className="flex items-center gap-1 text-[10px] text-text-muted hover:text-text-secondary transition-colors duration-200 flex-1"
+          >
+            {refsOpen ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
+            File references ({note.fileRefs.length})
+          </button>
+          <button
+            onClick={() => setPendingAttachToNoteId(note.id)}
+            className="text-[10px] text-[var(--color-accent-primary)] hover:underline transition-all duration-200"
+          >
+            + Attach
+          </button>
+        </div>
+        {refsOpen && note.fileRefs.length > 0 && (
+          <div className="px-3 pb-2 flex flex-col gap-1.5 max-h-40 overflow-y-auto">
+            {note.fileRefs.map((fileRef) => (
+              <FileRefItem key={fileRef.id} ref={fileRef} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/notes/NotesList.tsx
+++ b/src/components/notes/NotesList.tsx
@@ -1,0 +1,167 @@
+import { memo } from "react";
+import { StickyNote, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Note } from "@/lib/tauri";
+
+type Scope = "all" | "project" | "global";
+
+interface NotesListProps {
+  notes: Note[];
+  selectedId: string | null;
+  scope: Scope;
+  hasProject: boolean;
+  onSelectNote: (id: string) => void;
+  onNewNote: () => void;
+  onSetScope: (scope: Scope) => void;
+  onGoToFile: (filePath: string) => void;
+}
+
+function relativeTime(ms: number): string {
+  const diff = Date.now() - ms;
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/[*_`~]/g, "")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .trim();
+}
+
+function NotesListComponent({
+  notes,
+  selectedId,
+  scope,
+  hasProject,
+  onSelectNote,
+  onNewNote,
+  onSetScope,
+  onGoToFile,
+}: NotesListProps) {
+  const scopes: { id: Scope; label: string }[] = [
+    { id: "all", label: "All" },
+    ...(hasProject ? [{ id: "project" as Scope, label: "Project" }] : []),
+    { id: "global", label: "Global" },
+  ];
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Filter + New bar */}
+      <div className="flex items-center gap-1 px-3 py-2 border-b border-border-muted shrink-0">
+        <div className="flex items-center gap-1 flex-1">
+          {scopes.map((s) => (
+            <button
+              key={s.id}
+              onClick={() => onSetScope(s.id)}
+              className={cn(
+                "px-2 py-0.5 rounded-full text-[10px] font-medium transition-all duration-200",
+                scope === s.id
+                  ? "bg-[var(--color-accent-primary)] text-white"
+                  : "bg-bg-raised text-text-muted hover:text-text-secondary"
+              )}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={onNewNote}
+          title="New note"
+          className="flex items-center gap-1 px-2 py-1 rounded-lg text-[10px] bg-[var(--color-accent-primary)] text-white hover:opacity-90 transition-all duration-200"
+        >
+          <Plus size={10} />
+          New
+        </button>
+      </div>
+
+      {/* List */}
+      <div className="flex-1 overflow-y-auto">
+        {notes.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full gap-2 text-text-muted px-4 text-center">
+            <StickyNote size={24} className="opacity-30" />
+            <p className="text-xs">No notes yet</p>
+            <button
+              onClick={onNewNote}
+              className="text-[10px] text-[var(--color-accent-primary)] hover:underline"
+            >
+              Create your first note
+            </button>
+          </div>
+        ) : (
+          notes.map((note) => {
+            const isSelected = selectedId === note.id;
+            const preview = stripMarkdown(note.content);
+            const visibleRefs = note.fileRefs.slice(0, 3);
+            const extraRefs = note.fileRefs.length - 3;
+            return (
+              <div
+                key={note.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => onSelectNote(note.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") onSelectNote(note.id);
+                }}
+                className={cn(
+                  "w-full text-left px-3 py-2.5 border-b border-border-muted transition-all duration-200 cursor-pointer",
+                  isSelected ? "bg-bg-raised" : "hover:bg-bg-surface"
+                )}
+              >
+                <div className="flex items-center gap-1.5 mb-0.5">
+                  <StickyNote
+                    size={10}
+                    className={isSelected ? "text-[var(--color-accent-primary)] shrink-0" : "text-text-muted shrink-0"}
+                  />
+                  <span className={cn(
+                    "text-xs font-medium truncate flex-1",
+                    isSelected ? "text-text-primary" : "text-text-secondary"
+                  )}>
+                    {note.title || "(untitled)"}
+                  </span>
+                  <span className="text-[10px] text-text-muted shrink-0">
+                    {relativeTime(note.modified)}
+                  </span>
+                </div>
+                {preview && (
+                  <p className="text-[10px] text-text-muted line-clamp-1 ml-3.5">
+                    {preview}
+                  </p>
+                )}
+                {note.fileRefs.length > 0 && (
+                  <div className="flex items-center gap-1 mt-1 ml-3.5 flex-wrap">
+                    {visibleRefs.map((ref) => {
+                      const fileName = ref.filePath.replace(/\\/g, "/").split("/").pop() ?? ref.filePath;
+                      return (
+                        <button
+                          key={ref.id}
+                          onClick={(e) => { e.stopPropagation(); onGoToFile(ref.filePath); }}
+                          title={ref.filePath}
+                          className="text-[9px] px-1.5 py-0.5 rounded-full bg-bg-raised text-[var(--color-accent-primary)] hover:bg-[var(--color-accent-primary)] hover:text-white transition-all duration-200 font-mono truncate max-w-[80px]"
+                        >
+                          {fileName}
+                        </button>
+                      );
+                    })}
+                    {extraRefs > 0 && (
+                      <span className="text-[9px] text-text-muted">+{extraRefs} more</span>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const NotesList = memo(NotesListComponent);

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -1,0 +1,230 @@
+import { useState, useEffect, useMemo } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { NotesList } from "./NotesList";
+import { NoteEditor } from "./NoteEditor";
+import { useGlobalNotes, useProjectNotes } from "@/hooks/useClaudeData";
+import { useUIStore } from "@/stores/uiStore";
+import { useProjectsStore } from "@/stores/projectsStore";
+import { useSessionStore } from "@/stores/sessionStore";
+import { pathToProjectId } from "@/lib/utils";
+import * as tauri from "@/lib/tauri";
+import type { Note } from "@/lib/tauri";
+
+type Scope = "all" | "project" | "global";
+type View = "list" | "editor";
+
+function generateId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+export function NotesPanel() {
+  const queryClient = useQueryClient();
+  const activeProject = useProjectsStore((s) =>
+    s.projects.find((p) => p.id === s.activeProjectId)
+  );
+  const activeProjectId = useProjectsStore((s) => s.activeProjectId);
+  const openTab = useSessionStore((s) => s.openTab);
+  const pendingNoteRef = useUIStore((s) => s.pendingNoteRef);
+  const setPendingNoteRef = useUIStore((s) => s.setPendingNoteRef);
+  const pendingNoteId = useUIStore((s) => s.pendingNoteId);
+  const setPendingNoteId = useUIStore((s) => s.setPendingNoteId);
+  const pendingAttachToNoteId = useUIStore((s) => s.pendingAttachToNoteId);
+  const setPendingAttachToNoteId = useUIStore((s) => s.setPendingAttachToNoteId);
+  const setActiveNoteId = useUIStore((s) => s.setActiveNoteId);
+
+  const [view, setView] = useState<View>("list");
+  const [scope, setScope] = useState<Scope>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const { data: globalNotes = [] } = useGlobalNotes();
+  const { data: projectNotes = [] } = useProjectNotes(activeProject?.path ?? null);
+
+  const allNotes = useMemo(() => {
+    const map = new Map<string, Note>();
+    for (const n of [...globalNotes, ...projectNotes]) {
+      map.set(n.id, n);
+    }
+    return Array.from(map.values());
+  }, [globalNotes, projectNotes]);
+
+  const visibleNotes = useMemo(() => {
+    let notes: Note[];
+    if (scope === "global") {
+      notes = globalNotes;
+    } else if (scope === "project") {
+      notes = projectNotes;
+    } else {
+      notes = allNotes;
+    }
+    return [...notes].sort((a, b) => b.modified - a.modified);
+  }, [allNotes, globalNotes, projectNotes, scope]);
+
+  const selectedNote = useMemo(
+    () => visibleNotes.find((n) => n.id === selectedId) ?? null,
+    [visibleNotes, selectedId]
+  );
+
+  const saveMutation = useMutation({
+    mutationFn: (note: Note) => tauri.saveNote(note),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["notes"] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (note: Note) => {
+      const encodedProjectId = note.projectPath
+        ? pathToProjectId(note.projectPath)
+        : null;
+      return tauri.deleteNote(note.id, encodedProjectId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["notes"] });
+      setSelectedId(null);
+      setView("list");
+    },
+  });
+
+  // Sync view+selectedId → activeNoteId in uiStore so FileEditorTab can auto-attach
+  useEffect(() => {
+    setActiveNoteId(view === "editor" ? selectedId : null);
+    return () => setActiveNoteId(null);
+  }, [view, selectedId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Handle pendingNoteRef: attach to existing note if pendingAttachToNoteId is set,
+  // otherwise create a new note pre-filled with the file ref
+  useEffect(() => {
+    if (!pendingNoteRef) return;
+    if (pendingAttachToNoteId) {
+      const target = allNotes.find((n) => n.id === pendingAttachToNoteId);
+      if (target) {
+        const newRef = {
+          id: generateId(),
+          filePath: pendingNoteRef.filePath,
+          lineStart: pendingNoteRef.lineStart,
+          lineEnd: pendingNoteRef.lineEnd,
+          quote: pendingNoteRef.quote,
+        };
+        const updated = {
+          ...target,
+          fileRefs: [...target.fileRefs, newRef],
+          modified: Date.now(),
+        };
+        saveMutation.mutate(updated, {
+          onSuccess: () => {
+            setSelectedId(target.id);
+            setView("editor");
+            setPendingNoteRef(null);
+            setPendingAttachToNoteId(null);
+          },
+        });
+        return;
+      }
+    }
+    const now = Date.now();
+    const newNote: Note = {
+      id: generateId(),
+      title: "",
+      content: "",
+      projectPath: activeProject?.path ?? null,
+      fileRefs: [
+        {
+          id: generateId(),
+          filePath: pendingNoteRef.filePath,
+          lineStart: pendingNoteRef.lineStart,
+          lineEnd: pendingNoteRef.lineEnd,
+          quote: pendingNoteRef.quote,
+        },
+      ],
+      created: now,
+      modified: now,
+    };
+    saveMutation.mutate(newNote, {
+      onSuccess: () => {
+        setSelectedId(newNote.id);
+        setView("editor");
+        setPendingNoteRef(null);
+      },
+    });
+  }, [pendingNoteRef]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Handle pendingNoteId: jump directly to an existing note in editor view
+  useEffect(() => {
+    if (!pendingNoteId) return;
+    setSelectedId(pendingNoteId);
+    setView("editor");
+    setPendingNoteId(null);
+  }, [pendingNoteId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleNewNote = () => {
+    const now = Date.now();
+    const newNote: Note = {
+      id: generateId(),
+      title: "",
+      content: "",
+      projectPath: scope === "global" ? null : (activeProject?.path ?? null),
+      fileRefs: [],
+      created: now,
+      modified: now,
+    };
+    saveMutation.mutate(newNote, {
+      onSuccess: () => {
+        setSelectedId(newNote.id);
+        setView("editor");
+      },
+    });
+  };
+
+  const handleSelectNote = (id: string) => {
+    setSelectedId(id);
+    setView("editor");
+  };
+
+  const handleSave = (note: Note) => {
+    saveMutation.mutate(note);
+  };
+
+  const handleDelete = (note: Note) => {
+    deleteMutation.mutate(note);
+  };
+
+  const handleGoToFile = (filePath: string) => {
+    if (!activeProjectId) return;
+    const fileName = filePath.replace(/\\/g, "/").split("/").pop() ?? filePath;
+    const tabId = `file:${filePath}`;
+    openTab(
+      {
+        id: tabId,
+        type: "file",
+        title: fileName,
+        filePath,
+        projectDir: activeProject?.path ?? "",
+      },
+      activeProjectId
+    );
+  };
+
+  if (view === "editor" && selectedNote) {
+    return (
+      <NoteEditor
+        note={selectedNote}
+        onBack={() => setView("list")}
+        onSave={handleSave}
+        onDelete={handleDelete}
+      />
+    );
+  }
+
+  return (
+    <NotesList
+      notes={visibleNotes}
+      selectedId={selectedId}
+      scope={scope}
+      hasProject={!!activeProject}
+      onSelectNote={handleSelectNote}
+      onNewNote={handleNewNote}
+      onSetScope={setScope}
+      onGoToFile={handleGoToFile}
+    />
+  );
+}

--- a/src/components/settings/SettingsTab.tsx
+++ b/src/components/settings/SettingsTab.tsx
@@ -631,6 +631,31 @@ function LiveDangerouslySection() {
   );
 }
 
+function NotificationsSection() {
+  const { nativeNotificationsEnabled, setNativeNotificationsEnabled } = useSettingsStore();
+  return (
+    <div className="space-y-3">
+      <SectionLabel>Native Notifications</SectionLabel>
+      <div>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={nativeNotificationsEnabled}
+            onChange={(e) => setNativeNotificationsEnabled(e.target.checked)}
+            className="rounded-md"
+          />
+          <span className="text-xs font-medium text-text-secondary">
+            Show Windows notifications when app is in background
+          </span>
+        </label>
+        <p className="text-[11px] text-text-muted mt-1 ml-5">
+          Sends a toast to Windows Notification Center for Claude questions and session completions, only while the app is not focused.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 // ── Sticky section header ─────────────────────────────────────────────────────
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
@@ -788,6 +813,8 @@ export function SettingsTab() {
           <div className="space-y-6">
             <SessionTrackingSection />
             <LiveDangerouslySection />
+            <div className="border-t border-border-muted" />
+            <NotificationsSection />
           </div>
         </section>
       </div>

--- a/src/components/shell/RightActivityBar.tsx
+++ b/src/components/shell/RightActivityBar.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Brain, Users, FileText, BookOpen } from "lucide-react";
+import { Brain, Users, FileText, BookOpen, StickyNote } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useUIStore, type RightTab } from "@/stores/uiStore";
 
@@ -14,6 +14,7 @@ const rightItems: RightActivityItem[] = [
   { id: "teams", icon: Users, label: "Teams" },
   { id: "plans", icon: FileText, label: "Plans" },
   { id: "docs", icon: BookOpen, label: "Docs" },
+  { id: "notes", icon: StickyNote, label: "Notes" },
 ];
 
 function RightActivityBarComponent() {

--- a/src/index.css
+++ b/src/index.css
@@ -149,3 +149,12 @@ body {
   border-radius: 10px;
   box-shadow: inset 0 1px 3px rgba(0,0,0,0.3);
 }
+
+/* Monaco Editor — note gutter indicators */
+.note-gutter-indicator {
+  width: 3px !important;
+  background-color: var(--color-accent-primary);
+  border-radius: 2px;
+  cursor: pointer;
+  margin-left: 2px;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -93,6 +93,26 @@ export interface SummaryFile {
   preview: string;
 }
 
+// ---- Note Types ----
+
+export interface FileRef {
+  id: string;
+  filePath: string;
+  lineStart: number;
+  lineEnd: number;
+  quote: string;
+}
+
+export interface Note {
+  id: string;
+  title: string;
+  content: string;
+  projectPath: string | null;
+  fileRefs: FileRef[];
+  created: number;
+  modified: number;
+}
+
 // ---- Plan Types ----
 
 export type MarkdownLineKind = "Heading" | "CodeFence" | "CodeBlock" | "Normal";
@@ -234,6 +254,22 @@ export async function readPlan(filename: string): Promise<string> {
 
 export async function savePlan(filename: string, content: string): Promise<void> {
   return invoke("cmd_save_plan", { filename, content });
+}
+
+export function loadGlobalNotes(): Promise<Note[]> {
+  return invoke("cmd_load_global_notes");
+}
+
+export function loadProjectNotes(projectPath: string): Promise<Note[]> {
+  return invoke("cmd_load_project_notes", { projectPath });
+}
+
+export function saveNote(note: Note): Promise<void> {
+  return invoke("cmd_save_note", { note });
+}
+
+export function deleteNote(noteId: string, encodedProjectId: string | null): Promise<void> {
+  return invoke("cmd_delete_note", { noteId, encodedProjectId });
 }
 
 export async function gitStatus(cwd: string): Promise<GitStatus> {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -9,6 +9,7 @@ interface SettingsStore {
   fontFamily: string;
   openStartupFiles: boolean;
   dangerouslySkipPermissions: boolean;
+  nativeNotificationsEnabled: boolean;
 
   // GitHub (token in Windows Credential Manager, rest in settings.json)
   githubClientId: string;
@@ -30,6 +31,7 @@ interface SettingsStore {
   setFontFamily: (family: string) => void;
   setOpenStartupFiles: (value: boolean) => void;
   setDangerouslySkipPermissions: (value: boolean) => void;
+  setNativeNotificationsEnabled: (value: boolean) => void;
   setGithubClientId: (id: string) => void;
   setGithubToken: (token: string) => void;
   setGithubUsername: (name: string | null) => void;
@@ -47,6 +49,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   fontFamily: "Cascadia Code, JetBrains Mono, Fira Code, monospace",
   openStartupFiles: false,
   dangerouslySkipPermissions: false,
+  nativeNotificationsEnabled: true,
   githubClientId: "",
   githubToken: "",
   githubUsername: null,
@@ -59,23 +62,27 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
   setFontSize: (fontSize) => {
     set({ fontSize });
-    persistConfig({ fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
+    persistConfig({ fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions, nativeNotificationsEnabled: get().nativeNotificationsEnabled });
   },
   setFontFamily: (fontFamily) => {
     set({ fontFamily });
-    persistConfig({ fontSize: get().fontSize, fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
+    persistConfig({ fontSize: get().fontSize, fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions, nativeNotificationsEnabled: get().nativeNotificationsEnabled });
   },
   setOpenStartupFiles: (openStartupFiles) => {
     set({ openStartupFiles });
-    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions, nativeNotificationsEnabled: get().nativeNotificationsEnabled });
   },
   setDangerouslySkipPermissions: (dangerouslySkipPermissions) => {
     set({ dangerouslySkipPermissions });
-    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions, nativeNotificationsEnabled: get().nativeNotificationsEnabled });
+  },
+  setNativeNotificationsEnabled: (nativeNotificationsEnabled) => {
+    set({ nativeNotificationsEnabled });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions, nativeNotificationsEnabled });
   },
   setGithubClientId: (githubClientId) => {
     set({ githubClientId });
-    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions, nativeNotificationsEnabled: get().nativeNotificationsEnabled });
   },
   setGithubToken: (githubToken) => set({ githubToken }),
   setGithubUsername: (githubUsername) => set({ githubUsername }),
@@ -83,11 +90,11 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   setLinearUsername: (linearUsername) => set({ linearUsername }),
   setJiraBaseUrl: (jiraBaseUrl) => {
     set({ jiraBaseUrl });
-    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl, jiraEmail: get().jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions, nativeNotificationsEnabled: get().nativeNotificationsEnabled });
   },
   setJiraEmail: (jiraEmail) => {
     set({ jiraEmail });
-    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions });
+    persistConfig({ fontSize: get().fontSize, fontFamily: get().fontFamily, githubClientId: get().githubClientId, jiraBaseUrl: get().jiraBaseUrl, jiraEmail, openStartupFiles: get().openStartupFiles, dangerouslySkipPermissions: get().dangerouslySkipPermissions, nativeNotificationsEnabled: get().nativeNotificationsEnabled });
   },
   setJiraApiToken: (jiraApiToken) => set({ jiraApiToken }),
   setJiraUsername: (jiraUsername) => set({ jiraUsername }),
@@ -104,6 +111,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       const jiraEmail = await store.get<string>("jiraEmail");
       const openStartupFiles = await store.get<boolean>("openStartupFiles");
       const dangerouslySkipPermissions = await store.get<boolean>("dangerouslySkipPermissions");
+      const nativeNotificationsEnabled = await store.get<boolean>("nativeNotificationsEnabled");
       set({
         ...(fontSize != null && { fontSize }),
         ...(fontFamily != null && { fontFamily }),
@@ -112,6 +120,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         ...(jiraEmail != null && { jiraEmail }),
         ...(openStartupFiles != null && { openStartupFiles }),
         ...(dangerouslySkipPermissions != null && { dangerouslySkipPermissions }),
+        ...(nativeNotificationsEnabled != null && { nativeNotificationsEnabled }),
       });
       debugLog("Settings", "Config loaded from disk", { fontSize, fontFamily, githubClientId }, "success");
     } catch {
@@ -145,6 +154,7 @@ interface Config {
   jiraEmail: string;
   openStartupFiles: boolean;
   dangerouslySkipPermissions: boolean;
+  nativeNotificationsEnabled: boolean;
 }
 
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -162,6 +172,7 @@ function persistConfig(config: Config) {
       await store.set("jiraEmail", config.jiraEmail);
       await store.set("openStartupFiles", config.openStartupFiles);
       await store.set("dangerouslySkipPermissions", config.dangerouslySkipPermissions);
+      await store.set("nativeNotificationsEnabled", config.nativeNotificationsEnabled);
       await store.save();
     } catch {
       // not in Tauri context

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,8 +1,15 @@
 import { create } from "zustand";
 
 export type SidebarView = "sessions" | "git" | "prs" | "files";
-export type RightTab = "context" | "teams" | "plans" | "docs";
+export type RightTab = "context" | "teams" | "plans" | "docs" | "notes";
 export type BottomTab = "log" | "git" | "prs" | "issues" | "output" | "debug";
+
+export interface PendingNoteRef {
+  filePath: string;
+  lineStart: number;
+  lineEnd: number;
+  quote: string;
+}
 
 export interface SelectedDiffFile {
   cwd: string;
@@ -24,6 +31,10 @@ interface UIStore {
   tabInitStatus: Record<string, 'initializing' | 'error'>;
   tabInitError: Record<string, string>;
   tabReloadKey: Record<string, number>;
+  pendingNoteRef: PendingNoteRef | null;
+  pendingNoteId: string | null;
+  pendingAttachToNoteId: string | null;
+  activeNoteId: string | null;
 
   toggleSidebar: () => void;
   toggleRightPanel: () => void;
@@ -41,6 +52,12 @@ interface UIStore {
   setTabInitStatus: (tabId: string, status: 'initializing' | 'error' | null) => void;
   setTabInitError: (tabId: string, error: string | null) => void;
   bumpReloadKey: (tabId: string) => void;
+  setPendingNoteRef: (ref: PendingNoteRef | null) => void;
+  openNotesWithRef: (ref: PendingNoteRef) => void;
+  openNoteById: (id: string) => void;
+  setPendingNoteId: (id: string | null) => void;
+  setPendingAttachToNoteId: (id: string | null) => void;
+  setActiveNoteId: (id: string | null) => void;
 }
 
 export const useUIStore = create<UIStore>((set) => ({
@@ -57,6 +74,10 @@ export const useUIStore = create<UIStore>((set) => ({
   tabInitStatus: {},
   tabInitError: {},
   tabReloadKey: {},
+  pendingNoteRef: null,
+  pendingNoteId: null,
+  pendingAttachToNoteId: null,
+  activeNoteId: null,
 
   toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
   toggleRightPanel: () => set((s) => ({ rightPanelOpen: !s.rightPanelOpen })),
@@ -100,4 +121,10 @@ export const useUIStore = create<UIStore>((set) => ({
     set((s) => ({
       tabReloadKey: { ...s.tabReloadKey, [tabId]: (s.tabReloadKey[tabId] ?? 0) + 1 },
     })),
+  setPendingNoteRef: (ref) => set({ pendingNoteRef: ref }),
+  openNotesWithRef: (ref) => set({ pendingNoteRef: ref, activeRightTab: "notes", rightPanelOpen: true }),
+  openNoteById: (id) => set({ pendingNoteId: id, activeRightTab: "notes", rightPanelOpen: true }),
+  setPendingNoteId: (id) => set({ pendingNoteId: id }),
+  setPendingAttachToNoteId: (id) => set({ pendingAttachToNoteId: id }),
+  setActiveNoteId: (id) => set({ activeNoteId: id }),
 }));


### PR DESCRIPTION
## Summary

- **Notes system** — full Rust + React implementation: `Note` + `FileRef` models, per-project and global storage in `~/.claude/notes/`, `NotesPanel` / `NotesList` / `NoteEditor` components, right panel tab, file watcher invalidation
- **Monaco selection → note capture** — floating `"+ Add to note"` button on text selection, gutter line indicators for referenced lines, tab-bar dot for files with notes
- **Smart auto-attach** — when the notes panel is open with a note in editor view, the floating button shows `"+ Add to open note"` and appends directly to that note without requiring a pre-selection step; explicit `"+ Attach to note"` mode still takes priority
- **Native Windows notifications** — `tauri-plugin-notification` fires a toast for Claude questions and session completions when the app is unfocused; toggle in Settings → Claude
- **Jira error display** — surface Jira API errors in IssueListPanel (were silently swallowed)

## Test plan

- [ ] Open Notes tab (right panel) — list view shows global + project notes scoped correctly
- [ ] Create a new note from the list; editor opens with empty title/content
- [ ] In a file tab, select text → floating button appears above selection; click `"+ Add to note"` → new note created with file ref pre-filled
- [ ] With a note open in editor view, switch to a file tab, select text → button shows `"+ Add to open note"`; click → ref appended to the open note
- [ ] Click `"+ Attach"` in NoteEditor, navigate to file tab → button shows `"+ Attach to note"` (explicit overrides auto); attach works
- [ ] Gutter dot appears on referenced lines; clicking it jumps to the note
- [ ] Tab bar dot appears on file tabs that have notes; clicking it opens Notes panel
- [ ] Settings → Claude → enable Native Notifications; background a Claude session and trigger a question → Windows toast appears
- [ ] Jira configured but with bad credentials → error message visible in Issues tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)