### PR TITLE
feat: set up automated testing infrastructure for frontend and backend

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Run frontend tests
+        run: npm test
+
+      - name: Run Rust tests
+        working-directory: src-tauri
+        run: cargo test
+
       - name: Build Tauri app
         run: npx tauri build --no-bundle
         env:

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@
 | [Terminal & PTY](terminal.md) | How Claude CLI is spawned, ConPTY, xterm.js wiring, resize |
 | [Data Formats](data-formats.md) | `~/.claude/` file layout, path encoding, session JSONL, teams JSON |
 | [Integrations](integrations.md) | GitHub OAuth device flow, Linear API key, Jira token, `gh` CLI wiring |
+| [Testing](testing.md) | Vitest + RTL frontend tests, Rust `#[cfg(test)]` backend tests, CI integration |
 
 ## Design
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,86 @@
+# Testing
+
+Automated testing infrastructure for both the React frontend and Rust backend.
+
+## Quick reference
+
+```bash
+# Frontend
+npm test              # run all frontend tests once
+npm run test:watch    # run in watch mode (re-runs on file change)
+npm run test:coverage # run with coverage report
+
+# Backend (from src-tauri/)
+cargo test            # run all Rust tests
+cargo test sessions   # run tests matching "sessions"
+```
+
+## Frontend (Vitest + React Testing Library)
+
+**Stack:** Vitest 4 · React Testing Library · jsdom
+
+**Config:** `vitest.config.ts` — resolves `@/` alias, uses jsdom environment, loads setup file.
+
+**Setup file:** `src/test/setup.ts` — mocks all Tauri APIs (`@tauri-apps/api/core`, `@tauri-apps/plugin-store`, etc.) so tests run outside the Tauri webview.
+
+### Test file locations
+
+Tests live next to the code they test, following the `*.test.ts` / `*.test.tsx` convention:
+
+| Area | File | Tests |
+|------|------|-------|
+| Utilities | `src/lib/utils.test.ts` | `cn()`, `pathToProjectId()` |
+| Frontmatter parser | `src/lib/frontmatter.test.ts` | YAML frontmatter parsing |
+| UI store | `src/stores/uiStore.test.ts` | Panel toggles, view switching, notes |
+| Session store | `src/stores/sessionStore.test.ts` | Tab lifecycle, close/reorder, resolve |
+| Notification store | `src/stores/notificationStore.test.ts` | Add/read/clear, dedup, cap at 50 |
+| Output store | `src/stores/outputStore.test.ts` | Add messages, cap at 500 |
+| Debug store | `src/stores/debugStore.test.ts` | Entry creation, cap at 500 |
+
+### Writing new tests
+
+1. Create `*.test.ts` (or `.test.tsx` for components) next to the source file
+2. Zustand stores: use `useXxxStore.setState({...})` in `beforeEach` to reset state
+3. Tauri APIs are mocked globally — `invoke()`, `load()`, etc. are `vi.fn()` by default
+4. For component tests, use `@testing-library/react`'s `render()` and `screen` queries
+
+## Backend (Rust `#[cfg(test)]`)
+
+**Extra dev-dependency:** `tempfile` — creates temp directories for file I/O tests.
+
+### Test locations
+
+Tests use Rust's inline `#[cfg(test)] mod tests` convention:
+
+| Module | File | Tests |
+|--------|------|-------|
+| Path encoding | `data/path_encoding.rs` | Windows path → project ID encoding |
+| Sessions | `data/sessions.rs` | Index loading, JSONL scanning, filtering |
+| Notes | `data/notes.rs` | Save/load/delete, sorting, project scoping |
+| Todos | `data/todos.rs` | Load from dir, skip empties, sort |
+| Plans | `data/plans.rs` | Markdown parsing, title extraction, load |
+| Teams | `data/teams.rs` | Config loading, CWD filtering, fallback |
+| Transcripts | `models/transcript.rs` | Envelope parsing, all message types |
+
+### Writing new Rust tests
+
+1. Add `#[cfg(test)] mod tests { ... }` at the bottom of the module
+2. Use `tempfile::tempdir()` for any test that reads/writes files
+3. Use `#[test]` for sync tests, `#[tokio::test]` for async tests
+
+## CI Integration
+
+The `pr-build.yml` workflow runs both test suites before building:
+
+```
+npm ci → npm test → cargo test → tauri build
+```
+
+Tests must pass before the artifact is produced.
+
+## Decisions
+
+- **Vitest over Jest** — native ESM support, same config format as Vite, faster startup
+- **Tests next to source** — co-located `*.test.ts` files rather than a separate `tests/` tree, for easier navigation
+- **Tauri mocks in setup** — all `@tauri-apps/*` modules mocked globally so every test gets a clean baseline
+- **tempfile crate** — auto-cleanup temp dirs avoid polluting the filesystem during tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,13 +32,90 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
         "@tauri-apps/cli": "^2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "jsdom": "^28.1.0",
         "tailwindcss": "^4.0.0",
         "typescript": "~5.8.3",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -71,7 +148,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -275,6 +351,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -321,6 +407,151 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+      "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -763,6 +994,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1636,6 +1885,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.0.tgz",
@@ -2197,6 +2453,104 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2242,6 +2596,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2250,6 +2615,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2295,7 +2667,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2306,7 +2677,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2316,7 +2686,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2351,6 +2722,117 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
@@ -2382,8 +2864,42 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
     },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
@@ -2395,6 +2911,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/bail": {
@@ -2420,6 +2956,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -2440,7 +2986,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2484,6 +3029,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -2568,11 +3123,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.1.0.tgz",
+      "integrity": "sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2590,6 +3206,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -2642,11 +3265,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dompurify": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2671,6 +3303,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -2732,6 +3384,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -2839,6 +3511,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -2847,6 +3532,44 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inline-style-parser": {
@@ -2911,6 +3634,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2927,6 +3657,47 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3244,6 +4015,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3259,6 +4041,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3418,6 +4201,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -3861,6 +4651,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -3904,6 +4704,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -3929,6 +4740,26 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3942,7 +4773,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3979,6 +4809,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -3989,12 +4835,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4004,13 +4859,20 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -4128,6 +4990,20 @@
         }
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -4159,6 +5035,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -4206,6 +5092,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4221,6 +5120,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -4242,10 +5148,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stringify-entities": {
@@ -4260,6 +5180,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/style-to-js": {
@@ -4279,6 +5212,13 @@
       "dependencies": {
         "inline-style-parser": "0.2.7"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -4311,6 +5251,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4326,6 +5283,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -4366,6 +5379,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unified": {
@@ -4563,7 +5586,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4632,6 +5654,166 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
@@ -34,11 +37,16 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@tauri-apps/cli": "^2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "jsdom": "^28.1.0",
     "tailwindcss": "^4.0.0",
     "typescript": "~5.8.3",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4742,6 +4742,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-store",
+ "tempfile",
  "tokio",
  "windows",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,3 +38,6 @@ windows = { version = "0.61", features = [
     "Win32_UI_Shell",
     "Win32_UI_Shell_PropertiesSystem",
 ] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src-tauri/src/data/todos.rs
+++ b/src-tauri/src/data/todos.rs
@@ -46,3 +46,91 @@ pub fn load_todos(claude_home: &Path) -> Result<Vec<TodoFile>> {
     todo_files.sort_by(|a, b| a.filename.cmp(&b.filename));
     Ok(todo_files)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_todos_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = load_todos(tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_load_todos_with_items() {
+        let tmp = tempfile::tempdir().unwrap();
+        let todos_dir = tmp.path().join("todos");
+        std::fs::create_dir_all(&todos_dir).unwrap();
+
+        let items = r#"[
+            {"content": "Fix the bug", "status": "pending"},
+            {"content": "Write tests", "status": "completed", "activeForm": "Writing tests"}
+        ]"#;
+        std::fs::write(todos_dir.join("task1.json"), items).unwrap();
+
+        let result = load_todos(tmp.path()).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].filename, "task1.json");
+        assert_eq!(result[0].items.len(), 2);
+        assert_eq!(result[0].items[0].content.as_deref(), Some("Fix the bug"));
+    }
+
+    #[test]
+    fn test_load_todos_skips_empty_arrays() {
+        let tmp = tempfile::tempdir().unwrap();
+        let todos_dir = tmp.path().join("todos");
+        std::fs::create_dir_all(&todos_dir).unwrap();
+
+        std::fs::write(todos_dir.join("empty.json"), "[]").unwrap();
+        std::fs::write(
+            todos_dir.join("has-items.json"),
+            r#"[{"content": "Do something"}]"#,
+        )
+        .unwrap();
+
+        let result = load_todos(tmp.path()).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].filename, "has-items.json");
+    }
+
+    #[test]
+    fn test_load_todos_ignores_non_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let todos_dir = tmp.path().join("todos");
+        std::fs::create_dir_all(&todos_dir).unwrap();
+
+        std::fs::write(todos_dir.join("readme.md"), "# Todos").unwrap();
+
+        let result = load_todos(tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_load_todos_sorted_by_filename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let todos_dir = tmp.path().join("todos");
+        std::fs::create_dir_all(&todos_dir).unwrap();
+
+        let item = r#"[{"content": "item"}]"#;
+        std::fs::write(todos_dir.join("zzz.json"), item).unwrap();
+        std::fs::write(todos_dir.join("aaa.json"), item).unwrap();
+
+        let result = load_todos(tmp.path()).unwrap();
+        assert_eq!(result[0].filename, "aaa.json");
+        assert_eq!(result[1].filename, "zzz.json");
+    }
+
+    #[test]
+    fn test_load_todos_skips_invalid_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let todos_dir = tmp.path().join("todos");
+        std::fs::create_dir_all(&todos_dir).unwrap();
+
+        std::fs::write(todos_dir.join("bad.json"), "not json at all").unwrap();
+
+        let result = load_todos(tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+}

--- a/src/lib/frontmatter.test.ts
+++ b/src/lib/frontmatter.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { parseFrontmatter } from "./frontmatter";
+
+describe("parseFrontmatter", () => {
+  it("parses basic key-value frontmatter", () => {
+    const input = `---
+title: Hello World
+author: Test
+---
+Body content here`;
+
+    const result = parseFrontmatter(input);
+    expect(result.fm).toEqual({ title: "Hello World", author: "Test" });
+    expect(result.body).toBe("Body content here");
+  });
+
+  it("returns null fm when no frontmatter present", () => {
+    const input = "Just some text without frontmatter";
+    const result = parseFrontmatter(input);
+    expect(result.fm).toBeNull();
+    expect(result.body).toBe(input);
+  });
+
+  it("parses boolean values", () => {
+    const input = `---
+draft: true
+published: false
+---
+Content`;
+
+    const result = parseFrontmatter(input);
+    expect(result.fm).toEqual({ draft: true, published: false });
+  });
+
+  it("parses inline arrays", () => {
+    const input = `---
+tags: [react, typescript, testing]
+---
+Content`;
+
+    const result = parseFrontmatter(input);
+    expect(result.fm?.tags).toEqual(["react", "typescript", "testing"]);
+  });
+
+  it("parses bullet-list arrays", () => {
+    const input = `---
+tags:
+  - react
+  - typescript
+---
+Content`;
+
+    const result = parseFrontmatter(input);
+    expect(result.fm?.tags).toEqual(["react", "typescript"]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const input = "---\r\ntitle: Test\r\n---\r\nBody";
+    const result = parseFrontmatter(input);
+    expect(result.fm).toEqual({ title: "Test" });
+    expect(result.body).toBe("Body");
+  });
+
+  it("returns null fm for unclosed frontmatter", () => {
+    const input = `---
+title: Hello
+No closing delimiter`;
+
+    const result = parseFrontmatter(input);
+    expect(result.fm).toBeNull();
+  });
+
+  it("returns null fm for empty frontmatter block", () => {
+    const input = `---
+---
+Body`;
+
+    const result = parseFrontmatter(input);
+    expect(result.fm).toBeNull();
+  });
+
+  it("handles leading whitespace before opening delimiter", () => {
+    const input = `  ---
+title: Test
+---
+Body`;
+
+    const result = parseFrontmatter(input);
+    expect(result.fm).toEqual({ title: "Test" });
+  });
+});

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { cn, pathToProjectId } from "./utils";
+
+describe("cn", () => {
+  it("merges class names", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("handles conditional classes", () => {
+    expect(cn("base", false && "hidden", "visible")).toBe("base visible");
+  });
+
+  it("deduplicates tailwind classes", () => {
+    expect(cn("p-4", "p-2")).toBe("p-2");
+  });
+
+  it("returns empty string for no input", () => {
+    expect(cn()).toBe("");
+  });
+});
+
+describe("pathToProjectId", () => {
+  it("encodes a simple Windows path", () => {
+    expect(pathToProjectId("C:\\dev\\profile-server")).toBe(
+      "C--dev-profile-server"
+    );
+  });
+
+  it("encodes a worktree path", () => {
+    expect(
+      pathToProjectId("C:\\dev\\profile-server\\.worktrees\\aero-planning")
+    ).toBe("C--dev-profile-server-.worktrees-aero-planning");
+  });
+
+  it("encodes a deep path", () => {
+    expect(pathToProjectId("C:\\Users\\Keith\\projects\\my-app")).toBe(
+      "C--Users-Keith-projects-my-app"
+    );
+  });
+
+  it("handles forward slashes (unix-style input)", () => {
+    expect(pathToProjectId("C:/dev/ide")).toBe("C--dev-ide");
+  });
+
+  it("strips trailing dashes", () => {
+    expect(pathToProjectId("C:\\dev\\")).toBe("C--dev");
+  });
+
+  it("handles a root drive path (trailing dashes stripped)", () => {
+    // D:\ → D-- → trailing dashes stripped → D
+    expect(pathToProjectId("D:\\")).toBe("D");
+  });
+});

--- a/src/stores/debugStore.test.ts
+++ b/src/stores/debugStore.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useDebugStore } from "./debugStore";
+
+describe("debugStore", () => {
+  beforeEach(() => {
+    useDebugStore.setState({ entries: [], nextId: 1 });
+  });
+
+  it("adds a debug entry with incrementing id", () => {
+    useDebugStore.getState().addEntry({
+      category: "Test",
+      message: "Hello",
+      level: "info",
+    });
+
+    const entries = useDebugStore.getState().entries;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe(1);
+    expect(entries[0].category).toBe("Test");
+    expect(entries[0].message).toBe("Hello");
+    expect(entries[0].level).toBe("info");
+    expect(entries[0].timestamp).toMatch(/^\d{2}:\d{2}:\d{2}\.\d{3}$/);
+  });
+
+  it("increments IDs across entries", () => {
+    useDebugStore
+      .getState()
+      .addEntry({ category: "A", message: "1", level: "info" });
+    useDebugStore
+      .getState()
+      .addEntry({ category: "B", message: "2", level: "warn" });
+
+    const entries = useDebugStore.getState().entries;
+    expect(entries[0].id).toBe(1);
+    expect(entries[1].id).toBe(2);
+    expect(useDebugStore.getState().nextId).toBe(3);
+  });
+
+  it("stores optional data", () => {
+    useDebugStore.getState().addEntry({
+      category: "Test",
+      message: "With data",
+      data: { key: "value" },
+      level: "success",
+    });
+
+    expect(useDebugStore.getState().entries[0].data).toEqual({ key: "value" });
+  });
+
+  it("caps entries at 500", () => {
+    for (let i = 0; i < 510; i++) {
+      useDebugStore
+        .getState()
+        .addEntry({ category: "Bulk", message: `Entry ${i}`, level: "info" });
+    }
+
+    expect(useDebugStore.getState().entries).toHaveLength(500);
+  });
+
+  it("clears log and resets nextId", () => {
+    useDebugStore
+      .getState()
+      .addEntry({ category: "A", message: "1", level: "info" });
+    useDebugStore
+      .getState()
+      .addEntry({ category: "B", message: "2", level: "error" });
+    useDebugStore.getState().clearLog();
+
+    expect(useDebugStore.getState().entries).toHaveLength(0);
+    expect(useDebugStore.getState().nextId).toBe(1);
+  });
+});

--- a/src/stores/notificationStore.test.ts
+++ b/src/stores/notificationStore.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useNotificationStore } from "./notificationStore";
+
+describe("notificationStore", () => {
+  beforeEach(() => {
+    useNotificationStore.setState({ notifications: [] });
+  });
+
+  describe("addNotification", () => {
+    it("adds a question notification", () => {
+      useNotificationStore.getState().addNotification({
+        tabId: "tab1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        question: "Which approach?",
+      });
+
+      const notifs = useNotificationStore.getState().notifications;
+      expect(notifs).toHaveLength(1);
+      expect(notifs[0].type).toBe("question");
+      expect(notifs[0].read).toBe(false);
+    });
+
+    it("updates existing unread notification for same tab", () => {
+      useNotificationStore.getState().addNotification({
+        tabId: "tab1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        question: "First question",
+      });
+
+      useNotificationStore.getState().addNotification({
+        tabId: "tab1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        question: "Updated question",
+      });
+
+      const notifs = useNotificationStore.getState().notifications;
+      expect(notifs).toHaveLength(1);
+      if (notifs[0].type === "question") {
+        expect(notifs[0].question).toBe("Updated question");
+      }
+    });
+
+    it("creates new notification for same tab after marking read", () => {
+      useNotificationStore.getState().addNotification({
+        tabId: "tab1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        question: "First question",
+      });
+
+      const id = useNotificationStore.getState().notifications[0].id;
+      useNotificationStore.getState().markRead(id);
+
+      useNotificationStore.getState().addNotification({
+        tabId: "tab1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        question: "New question",
+      });
+
+      const notifs = useNotificationStore.getState().notifications;
+      expect(notifs).toHaveLength(1);
+      expect(notifs[0].read).toBe(false);
+    });
+  });
+
+  describe("addCompletionNotification", () => {
+    it("adds a completion notification", () => {
+      useNotificationStore.getState().addCompletionNotification({
+        sessionId: "sess1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        filename: "summary-001.md",
+        preview: "Task completed",
+      });
+
+      const notifs = useNotificationStore.getState().notifications;
+      expect(notifs).toHaveLength(1);
+      expect(notifs[0].type).toBe("completion");
+    });
+
+    it("deduplicates by sessionId and filename", () => {
+      const notif = {
+        sessionId: "sess1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        filename: "summary-001.md",
+        preview: "Task completed",
+      };
+
+      useNotificationStore.getState().addCompletionNotification(notif);
+      useNotificationStore.getState().addCompletionNotification(notif);
+
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+  });
+
+  describe("markRead", () => {
+    it("marks a notification as read", () => {
+      useNotificationStore.getState().addNotification({
+        tabId: "tab1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        question: "Question?",
+      });
+
+      const id = useNotificationStore.getState().notifications[0].id;
+      useNotificationStore.getState().markRead(id);
+
+      expect(useNotificationStore.getState().notifications[0].read).toBe(true);
+    });
+  });
+
+  describe("markReadByTabId", () => {
+    it("marks all notifications for a tab as read", () => {
+      useNotificationStore.getState().addNotification({
+        tabId: "tab1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        question: "Q1",
+      });
+
+      // Mark first as read, then add another
+      const id = useNotificationStore.getState().notifications[0].id;
+      useNotificationStore.getState().markRead(id);
+      useNotificationStore.getState().addNotification({
+        tabId: "tab1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        question: "Q2",
+      });
+
+      useNotificationStore.getState().markReadByTabId("tab1");
+
+      const allRead = useNotificationStore
+        .getState()
+        .notifications.every((n) => n.read);
+      expect(allRead).toBe(true);
+    });
+  });
+
+  describe("removeNotification", () => {
+    it("removes a notification by id", () => {
+      useNotificationStore.getState().addNotification({
+        tabId: "tab1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        question: "Q1",
+      });
+
+      const id = useNotificationStore.getState().notifications[0].id;
+      useNotificationStore.getState().removeNotification(id);
+
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+  });
+
+  describe("clearAll", () => {
+    it("clears all notifications", () => {
+      useNotificationStore.getState().addNotification({
+        tabId: "tab1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        question: "Q1",
+      });
+      useNotificationStore.getState().addCompletionNotification({
+        sessionId: "sess1",
+        projectId: "proj1",
+        sessionTitle: "Session 1",
+        filename: "f.md",
+        preview: "done",
+      });
+
+      useNotificationStore.getState().clearAll();
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+  });
+
+  describe("max notifications", () => {
+    it("caps notifications at 50", () => {
+      for (let i = 0; i < 55; i++) {
+        useNotificationStore.getState().addNotification({
+          tabId: `tab-${i}`,
+          projectId: "proj1",
+          sessionTitle: `Session ${i}`,
+          question: `Question ${i}`,
+        });
+      }
+
+      expect(
+        useNotificationStore.getState().notifications.length
+      ).toBeLessThanOrEqual(50);
+    });
+  });
+});

--- a/src/stores/outputStore.test.ts
+++ b/src/stores/outputStore.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useOutputStore } from "./outputStore";
+
+describe("outputStore", () => {
+  beforeEach(() => {
+    useOutputStore.setState({ messages: [] });
+  });
+
+  it("adds a message", () => {
+    useOutputStore.getState().addMessage("info", "Test message", "test");
+
+    const msgs = useOutputStore.getState().messages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].level).toBe("info");
+    expect(msgs[0].text).toBe("Test message");
+    expect(msgs[0].source).toBe("test");
+    expect(msgs[0].timestamp).toBeDefined();
+    expect(msgs[0].id).toBeDefined();
+  });
+
+  it("supports all message levels", () => {
+    useOutputStore.getState().addMessage("info", "Info msg", "test");
+    useOutputStore.getState().addMessage("success", "Success msg", "test");
+    useOutputStore.getState().addMessage("error", "Error msg", "test");
+
+    const levels = useOutputStore.getState().messages.map((m) => m.level);
+    expect(levels).toEqual(["info", "success", "error"]);
+  });
+
+  it("caps messages at 500", () => {
+    for (let i = 0; i < 510; i++) {
+      useOutputStore.getState().addMessage("info", `Message ${i}`, "test");
+    }
+
+    expect(useOutputStore.getState().messages).toHaveLength(500);
+    // Should keep the most recent messages
+    expect(useOutputStore.getState().messages[499].text).toBe("Message 509");
+  });
+
+  it("clears all messages", () => {
+    useOutputStore.getState().addMessage("info", "msg1", "test");
+    useOutputStore.getState().addMessage("info", "msg2", "test");
+    useOutputStore.getState().clear();
+
+    expect(useOutputStore.getState().messages).toHaveLength(0);
+  });
+});

--- a/src/stores/sessionStore.test.ts
+++ b/src/stores/sessionStore.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useSessionStore, type SessionTab } from "./sessionStore";
+
+const makeTab = (overrides: Partial<SessionTab> = {}): SessionTab => ({
+  id: `tab-${Math.random().toString(36).slice(2, 7)}`,
+  projectDir: "C:\\dev\\test",
+  title: "Test Tab",
+  ...overrides,
+});
+
+const PROJECT = "test-project";
+
+describe("sessionStore", () => {
+  beforeEach(() => {
+    useSessionStore.setState({
+      tabsByProject: {},
+      activeTabByProject: {},
+      activeSubagents: {},
+      knownSessions: {},
+      planLinks: {},
+      dirtyTabs: {},
+    });
+  });
+
+  describe("openTab", () => {
+    it("opens a new tab and makes it active", () => {
+      const tab = makeTab({ id: "tab1" });
+      useSessionStore.getState().openTab(tab, PROJECT);
+
+      const state = useSessionStore.getState();
+      expect(state.tabsByProject[PROJECT]).toHaveLength(1);
+      expect(state.tabsByProject[PROJECT]![0].id).toBe("tab1");
+      expect(state.activeTabByProject[PROJECT]).toBe("tab1");
+    });
+
+    it("focuses existing tab without duplicating", () => {
+      const tab = makeTab({ id: "tab1" });
+      useSessionStore.getState().openTab(tab, PROJECT);
+      useSessionStore.getState().openTab(makeTab({ id: "tab2" }), PROJECT);
+      useSessionStore.getState().openTab(tab, PROJECT);
+
+      const state = useSessionStore.getState();
+      expect(state.tabsByProject[PROJECT]).toHaveLength(2);
+      expect(state.activeTabByProject[PROJECT]).toBe("tab1");
+    });
+
+    it("adds spawnedAt timestamp", () => {
+      const tab = makeTab({ id: "tab1" });
+      useSessionStore.getState().openTab(tab, PROJECT);
+
+      const state = useSessionStore.getState();
+      expect(state.tabsByProject[PROJECT]![0].spawnedAt).toBeDefined();
+    });
+  });
+
+  describe("closeTab", () => {
+    it("removes a tab and selects the last remaining tab", () => {
+      const tab1 = makeTab({ id: "tab1" });
+      const tab2 = makeTab({ id: "tab2" });
+      useSessionStore.getState().openTab(tab1, PROJECT);
+      useSessionStore.getState().openTab(tab2, PROJECT);
+
+      useSessionStore.getState().closeTab("tab2", PROJECT);
+
+      const state = useSessionStore.getState();
+      expect(state.tabsByProject[PROJECT]).toHaveLength(1);
+      expect(state.activeTabByProject[PROJECT]).toBe("tab1");
+    });
+
+    it("sets active to null when closing the last tab", () => {
+      const tab = makeTab({ id: "tab1" });
+      useSessionStore.getState().openTab(tab, PROJECT);
+      useSessionStore.getState().closeTab("tab1", PROJECT);
+
+      const state = useSessionStore.getState();
+      expect(state.tabsByProject[PROJECT]).toHaveLength(0);
+      expect(state.activeTabByProject[PROJECT]).toBeNull();
+    });
+
+    it("preserves active tab when closing a non-active tab", () => {
+      const tab1 = makeTab({ id: "tab1" });
+      const tab2 = makeTab({ id: "tab2" });
+      useSessionStore.getState().openTab(tab1, PROJECT);
+      useSessionStore.getState().openTab(tab2, PROJECT);
+      // tab2 is active
+      useSessionStore.getState().closeTab("tab1", PROJECT);
+
+      expect(useSessionStore.getState().activeTabByProject[PROJECT]).toBe(
+        "tab2"
+      );
+    });
+  });
+
+  describe("setActiveTab", () => {
+    it("changes the active tab", () => {
+      useSessionStore.getState().openTab(makeTab({ id: "tab1" }), PROJECT);
+      useSessionStore.getState().openTab(makeTab({ id: "tab2" }), PROJECT);
+      useSessionStore.getState().setActiveTab("tab1", PROJECT);
+
+      expect(useSessionStore.getState().activeTabByProject[PROJECT]).toBe(
+        "tab1"
+      );
+    });
+  });
+
+  describe("insertTabBackground", () => {
+    it("adds tab without changing active tab", () => {
+      useSessionStore.getState().openTab(makeTab({ id: "tab1" }), PROJECT);
+      useSessionStore
+        .getState()
+        .insertTabBackground(makeTab({ id: "bg-tab" }), PROJECT);
+
+      const state = useSessionStore.getState();
+      expect(state.tabsByProject[PROJECT]).toHaveLength(2);
+      expect(state.activeTabByProject[PROJECT]).toBe("tab1");
+    });
+
+    it("does not duplicate existing tabs", () => {
+      const tab = makeTab({ id: "tab1" });
+      useSessionStore.getState().openTab(tab, PROJECT);
+      useSessionStore.getState().insertTabBackground(tab, PROJECT);
+
+      expect(useSessionStore.getState().tabsByProject[PROJECT]).toHaveLength(1);
+    });
+  });
+
+  describe("openPlanTab", () => {
+    it("creates a plan tab", () => {
+      useSessionStore.getState().openPlanTab("plan.md", "My Plan", PROJECT);
+
+      const state = useSessionStore.getState();
+      const planTab = state.tabsByProject[PROJECT]?.find(
+        (t) => t.id === "plan:plan.md"
+      );
+      expect(planTab).toBeDefined();
+      expect(planTab?.type).toBe("plan");
+      expect(planTab?.planFilename).toBe("plan.md");
+    });
+
+    it("does not duplicate plan tabs", () => {
+      useSessionStore.getState().openPlanTab("plan.md", "My Plan", PROJECT);
+      useSessionStore.getState().openPlanTab("plan.md", "My Plan", PROJECT);
+
+      expect(useSessionStore.getState().tabsByProject[PROJECT]).toHaveLength(1);
+    });
+  });
+
+  describe("closeAllTabs", () => {
+    it("removes all tabs for a project", () => {
+      useSessionStore.getState().openTab(makeTab({ id: "tab1" }), PROJECT);
+      useSessionStore.getState().openTab(makeTab({ id: "tab2" }), PROJECT);
+      useSessionStore.getState().closeAllTabs(PROJECT);
+
+      const state = useSessionStore.getState();
+      expect(state.tabsByProject[PROJECT]).toHaveLength(0);
+      expect(state.activeTabByProject[PROJECT]).toBeNull();
+    });
+  });
+
+  describe("closeOtherTabs", () => {
+    it("keeps only the specified tab", () => {
+      useSessionStore.getState().openTab(makeTab({ id: "tab1" }), PROJECT);
+      useSessionStore.getState().openTab(makeTab({ id: "tab2" }), PROJECT);
+      useSessionStore.getState().openTab(makeTab({ id: "tab3" }), PROJECT);
+      useSessionStore.getState().closeOtherTabs("tab2", PROJECT);
+
+      const state = useSessionStore.getState();
+      expect(state.tabsByProject[PROJECT]).toHaveLength(1);
+      expect(state.tabsByProject[PROJECT]![0].id).toBe("tab2");
+    });
+  });
+
+  describe("closeTabsToLeft", () => {
+    it("removes tabs to the left of the specified tab", () => {
+      useSessionStore.getState().openTab(makeTab({ id: "tab1" }), PROJECT);
+      useSessionStore.getState().openTab(makeTab({ id: "tab2" }), PROJECT);
+      useSessionStore.getState().openTab(makeTab({ id: "tab3" }), PROJECT);
+      useSessionStore.getState().closeTabsToLeft("tab2", PROJECT);
+
+      const ids = useSessionStore
+        .getState()
+        .tabsByProject[PROJECT]!.map((t) => t.id);
+      expect(ids).toEqual(["tab2", "tab3"]);
+    });
+  });
+
+  describe("closeTabsToRight", () => {
+    it("removes tabs to the right of the specified tab", () => {
+      useSessionStore.getState().openTab(makeTab({ id: "tab1" }), PROJECT);
+      useSessionStore.getState().openTab(makeTab({ id: "tab2" }), PROJECT);
+      useSessionStore.getState().openTab(makeTab({ id: "tab3" }), PROJECT);
+      useSessionStore.getState().closeTabsToRight("tab2", PROJECT);
+
+      const ids = useSessionStore
+        .getState()
+        .tabsByProject[PROJECT]!.map((t) => t.id);
+      expect(ids).toEqual(["tab1", "tab2"]);
+    });
+  });
+
+  describe("resolveTabSession", () => {
+    it("sets the resolved session ID on a tab across all projects", () => {
+      useSessionStore.getState().openTab(makeTab({ id: "tab1" }), PROJECT);
+      useSessionStore.getState().resolveTabSession("tab1", "real-session-id");
+
+      const tab = useSessionStore.getState().tabsByProject[PROJECT]![0];
+      expect(tab.resolvedSessionId).toBe("real-session-id");
+    });
+  });
+
+  describe("renameTab", () => {
+    it("renames a tab", () => {
+      useSessionStore.getState().openTab(makeTab({ id: "tab1" }), PROJECT);
+      useSessionStore.getState().renameTab("tab1", "New Title");
+
+      const tab = useSessionStore.getState().tabsByProject[PROJECT]![0];
+      expect(tab.title).toBe("New Title");
+    });
+  });
+
+  describe("session status", () => {
+    it("marks session as active/idle/completed", () => {
+      useSessionStore.getState().markSessionStatus("sess1", "active");
+      expect(useSessionStore.getState().knownSessions["sess1"]).toBe("active");
+
+      useSessionStore.getState().markSessionStatus("sess1", "completed");
+      expect(useSessionStore.getState().knownSessions["sess1"]).toBe(
+        "completed"
+      );
+    });
+  });
+
+  describe("subagents", () => {
+    it("sets subagents for a session", () => {
+      const subs = [
+        { sessionId: "sub1", parentSessionId: "sess1", name: "Agent 1" },
+      ];
+      useSessionStore.getState().setSubagents("sess1", subs);
+      expect(useSessionStore.getState().activeSubagents["sess1"]).toEqual(subs);
+    });
+  });
+
+  describe("dirtyTabs", () => {
+    it("marks and unmarks a tab as dirty", () => {
+      useSessionStore.getState().setTabDirty("tab1", true);
+      expect(useSessionStore.getState().dirtyTabs["tab1"]).toBe(true);
+
+      useSessionStore.getState().setTabDirty("tab1", false);
+      expect(useSessionStore.getState().dirtyTabs["tab1"]).toBeUndefined();
+    });
+  });
+
+  describe("resumeTab", () => {
+    it("clears the tab type", () => {
+      useSessionStore
+        .getState()
+        .openTab(
+          makeTab({ id: "tab1", type: "session-view" }),
+          PROJECT
+        );
+      useSessionStore.getState().resumeTab("tab1", PROJECT);
+
+      const tab = useSessionStore.getState().tabsByProject[PROJECT]![0];
+      expect(tab.type).toBeUndefined();
+    });
+  });
+});

--- a/src/stores/uiStore.test.ts
+++ b/src/stores/uiStore.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useUIStore } from "./uiStore";
+
+describe("uiStore", () => {
+  beforeEach(() => {
+    // Reset store to default state before each test
+    useUIStore.setState({
+      sidebarOpen: true,
+      rightPanelOpen: true,
+      bottomPanelOpen: true,
+      activeSidebarView: "sessions",
+      activeRightTab: "context",
+      activeBottomTab: "log",
+      commandPaletteOpen: false,
+      neuralFieldOpen: false,
+      projectDropdownOpen: false,
+      tabInitStatus: {},
+      tabInitError: {},
+      tabReloadKey: {},
+      pendingNoteRef: null,
+      pendingNoteId: null,
+      pendingAttachToNoteId: null,
+      activeNoteId: null,
+    });
+  });
+
+  describe("panel toggles", () => {
+    it("toggles sidebar", () => {
+      expect(useUIStore.getState().sidebarOpen).toBe(true);
+      useUIStore.getState().toggleSidebar();
+      expect(useUIStore.getState().sidebarOpen).toBe(false);
+      useUIStore.getState().toggleSidebar();
+      expect(useUIStore.getState().sidebarOpen).toBe(true);
+    });
+
+    it("toggles right panel", () => {
+      expect(useUIStore.getState().rightPanelOpen).toBe(true);
+      useUIStore.getState().toggleRightPanel();
+      expect(useUIStore.getState().rightPanelOpen).toBe(false);
+    });
+
+    it("toggles bottom panel", () => {
+      expect(useUIStore.getState().bottomPanelOpen).toBe(true);
+      useUIStore.getState().toggleBottomPanel();
+      expect(useUIStore.getState().bottomPanelOpen).toBe(false);
+    });
+  });
+
+  describe("view switching", () => {
+    it("sets sidebar view and opens sidebar", () => {
+      useUIStore.setState({ sidebarOpen: false });
+      useUIStore.getState().setSidebarView("git");
+      expect(useUIStore.getState().activeSidebarView).toBe("git");
+      expect(useUIStore.getState().sidebarOpen).toBe(true);
+    });
+
+    it("sets right tab", () => {
+      useUIStore.getState().setRightTab("plans");
+      expect(useUIStore.getState().activeRightTab).toBe("plans");
+    });
+
+    it("sets bottom tab", () => {
+      useUIStore.getState().setBottomTab("output");
+      expect(useUIStore.getState().activeBottomTab).toBe("output");
+    });
+  });
+
+  describe("command palette", () => {
+    it("opens and closes command palette", () => {
+      expect(useUIStore.getState().commandPaletteOpen).toBe(false);
+      useUIStore.getState().openCommandPalette();
+      expect(useUIStore.getState().commandPaletteOpen).toBe(true);
+      useUIStore.getState().closeCommandPalette();
+      expect(useUIStore.getState().commandPaletteOpen).toBe(false);
+    });
+  });
+
+  describe("neural field", () => {
+    it("toggles neural field", () => {
+      expect(useUIStore.getState().neuralFieldOpen).toBe(false);
+      useUIStore.getState().toggleNeuralField();
+      expect(useUIStore.getState().neuralFieldOpen).toBe(true);
+      useUIStore.getState().toggleNeuralField();
+      expect(useUIStore.getState().neuralFieldOpen).toBe(false);
+    });
+  });
+
+  describe("debug panel", () => {
+    it("opens debug panel when not currently showing debug", () => {
+      useUIStore.setState({ activeBottomTab: "log", bottomPanelOpen: false });
+      useUIStore.getState().toggleDebugPanel();
+      expect(useUIStore.getState().activeBottomTab).toBe("debug");
+      expect(useUIStore.getState().bottomPanelOpen).toBe(true);
+    });
+
+    it("closes bottom panel when debug is already active and open", () => {
+      useUIStore.setState({ activeBottomTab: "debug", bottomPanelOpen: true });
+      useUIStore.getState().toggleDebugPanel();
+      expect(useUIStore.getState().bottomPanelOpen).toBe(false);
+    });
+  });
+
+  describe("project dropdown", () => {
+    it("opens and closes project dropdown", () => {
+      expect(useUIStore.getState().projectDropdownOpen).toBe(false);
+      useUIStore.getState().openProjectDropdown();
+      expect(useUIStore.getState().projectDropdownOpen).toBe(true);
+      useUIStore.getState().closeProjectDropdown();
+      expect(useUIStore.getState().projectDropdownOpen).toBe(false);
+    });
+  });
+
+  describe("tab init status", () => {
+    it("sets and clears tab init status", () => {
+      useUIStore.getState().setTabInitStatus("tab1", "initializing");
+      expect(useUIStore.getState().tabInitStatus["tab1"]).toBe("initializing");
+
+      useUIStore.getState().setTabInitStatus("tab1", "error");
+      expect(useUIStore.getState().tabInitStatus["tab1"]).toBe("error");
+
+      useUIStore.getState().setTabInitStatus("tab1", null);
+      expect(useUIStore.getState().tabInitStatus["tab1"]).toBeUndefined();
+    });
+  });
+
+  describe("tab init error", () => {
+    it("sets and clears tab init error", () => {
+      useUIStore.getState().setTabInitError("tab1", "Something went wrong");
+      expect(useUIStore.getState().tabInitError["tab1"]).toBe(
+        "Something went wrong"
+      );
+
+      useUIStore.getState().setTabInitError("tab1", null);
+      expect(useUIStore.getState().tabInitError["tab1"]).toBeUndefined();
+    });
+  });
+
+  describe("reload key", () => {
+    it("increments reload key from 0", () => {
+      useUIStore.getState().bumpReloadKey("tab1");
+      expect(useUIStore.getState().tabReloadKey["tab1"]).toBe(1);
+    });
+
+    it("increments reload key from existing value", () => {
+      useUIStore.getState().bumpReloadKey("tab1");
+      useUIStore.getState().bumpReloadKey("tab1");
+      expect(useUIStore.getState().tabReloadKey["tab1"]).toBe(2);
+    });
+  });
+
+  describe("notes integration", () => {
+    it("opens notes with a pending ref", () => {
+      const ref = {
+        filePath: "/test/file.ts",
+        lineStart: 1,
+        lineEnd: 5,
+        quote: "some code",
+      };
+      useUIStore.getState().openNotesWithRef(ref);
+      expect(useUIStore.getState().pendingNoteRef).toEqual(ref);
+      expect(useUIStore.getState().activeRightTab).toBe("notes");
+      expect(useUIStore.getState().rightPanelOpen).toBe(true);
+    });
+
+    it("opens a note by id", () => {
+      useUIStore.getState().openNoteById("note-123");
+      expect(useUIStore.getState().pendingNoteId).toBe("note-123");
+      expect(useUIStore.getState().activeRightTab).toBe("notes");
+      expect(useUIStore.getState().rightPanelOpen).toBe(true);
+    });
+
+    it("sets active note id", () => {
+      useUIStore.getState().setActiveNoteId("note-456");
+      expect(useUIStore.getState().activeNoteId).toBe("note-456");
+    });
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,53 @@
+import "@testing-library/jest-dom/vitest";
+
+// Mock Tauri APIs — these don't exist outside the Tauri webview context
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+  emit: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-store", () => ({
+  load: vi.fn(() =>
+    Promise.resolve({
+      get: vi.fn(() => Promise.resolve(null)),
+      set: vi.fn(() => Promise.resolve()),
+      save: vi.fn(() => Promise.resolve()),
+    })
+  ),
+}));
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+  exists: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  Command: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-notification", () => ({
+  isPermissionGranted: vi.fn(() => Promise.resolve(true)),
+  requestPermission: vi.fn(() => Promise.resolve("granted")),
+  sendNotification: vi.fn(),
+}));
+
+// Mock crypto.randomUUID for notification IDs
+if (!globalThis.crypto) {
+  Object.defineProperty(globalThis, "crypto", {
+    value: {
+      randomUUID: () =>
+        "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+          const r = (Math.random() * 16) | 0;
+          const v = c === "x" ? r : (r & 0x3) | 0x8;
+          return v.toString(16);
+        }),
+    },
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+    css: false,
+  },
+});


### PR DESCRIPTION
Add Vitest + React Testing Library for the frontend (77 tests) covering all
Zustand stores, utility functions, and the frontmatter parser. Add Rust
#[cfg(test)] modules with tempfile for the backend (54 tests) covering
path encoding, sessions, notes, todos, plans, teams, and transcript parsing.

CI pipeline (pr-build.yml) now runs both test suites before building.

https://claude.ai/code/session_01NU2mnehd7jNZLCQ27dPemy