### PR TITLE
fix: rename bottom tab id 'log' → 'git'

### DIFF
--- a/src/components/layout/BottomPanel.tsx
+++ b/src/components/layout/BottomPanel.tsx
@@ -7,12 +7,12 @@ import { OutputPanel } from "@/components/layout/OutputPanel";
 import { DebugPanel } from "@/components/debug/DebugPanel";
 
 const BASE_TABS: { id: BottomTab; label: string }[] = [
-  { id: "log", label: "Git" },
+  { id: "git", label: "Git" },
   { id: "output", label: "Output" },
 ];
 
 const tabPlaceholders: Record<BottomTab, string> = {
-  log: "Select a project to view git log.",
+  git: "Select a project to view git log.",
   output: "No output.",
   debug: "No debug entries.",
 };
@@ -52,7 +52,7 @@ function BottomPanelComponent() {
       </div>
 
       {/* Content */}
-      {activeTab === "log" ? (
+      {activeTab === "git" ? (
         <div className="flex-1 overflow-hidden">
           <GitLogPanel />
         </div>

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 export type SidebarView = "sessions" | "git" | "prs" | "issues" | "files";
 export type RightTab = "context" | "teams" | "plans" | "docs" | "notes";
-export type BottomTab = "log" | "output" | "debug";
+export type BottomTab = "git" | "output" | "debug";
 
 export interface PendingNoteRef {
   filePath: string;
@@ -58,7 +58,7 @@ export const useUIStore = create<UIStore>((set) => ({
   bottomPanelOpen: true,
   activeSidebarView: "sessions",
   activeRightTab: "context",
-  activeBottomTab: "log",
+  activeBottomTab: "git",
   commandPaletteOpen: false,
   neuralFieldOpen: false,
   projectDropdownOpen: false,


### PR DESCRIPTION
## Summary

- `src/stores/uiStore.ts`: `BottomTab` union type `"log"` → `"git"`; initial `activeBottomTab` default `"log"` → `"git"`
- `src/components/layout/BottomPanel.tsx`: `BASE_TABS` entry id, `tabPlaceholders` key, and `activeTab` conditional all `"log"` → `"git"`

Fixes the two `TS2345` errors introduced when `useKeyBindings.ts` and `commands.ts` were updated to call `setBottomTab("git")` in refactor `ff05d5b` but the store type and panel component weren't updated to match.

## Test plan

- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] Bottom panel Git tab renders and opens git log on Ctrl+Shift+G

🤖 Generated with [Claude Code](https://claude.com/claude-code)