### PR TITLE
Disable Claude AI workflow automations

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,22 +1,11 @@
-name: Claude Code Review
+name: Claude Code Review (disabled)
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_dispatch:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: false
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,22 +1,11 @@
-name: Claude Code
+name: Claude Code (disabled)
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  workflow_dispatch:
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
This PR disables the Claude AI code review and interactive workflows by converting them from event-triggered automations to manual-only workflows that are explicitly disabled.

## Key Changes
- **claude-code-review.yml**: Converted from automatic PR trigger to `workflow_dispatch` only, with `if: false` condition to prevent execution
  - Removed automatic triggers: `pull_request` events (opened, synchronize, ready_for_review, reopened)
  - Removed optional path filters and author-based conditional logic
  
- **claude.yml**: Converted from multiple event-based triggers to `workflow_dispatch` only, with `if: false` condition to prevent execution
  - Removed automatic triggers: `issue_comment`, `pull_request_review_comment`, `issues`, and `pull_request_review` events
  - Removed complex conditional logic that checked for `@claude` mentions across different event types

## Implementation Details
Both workflows are now effectively disabled through a combination of:
1. Changing the trigger mechanism from automatic events to `workflow_dispatch` (manual trigger only)
2. Adding an explicit `if: false` condition to the job, ensuring it never executes even if manually triggered

This approach maintains the workflow files in the repository while preventing any automated Claude AI interactions.

https://claude.ai/code/session_01CinzKaASRCJbLuiG9M1a2j