### PR TITLE
feat: add GitHub Workflows panel to bottom pane

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,3 +15,4 @@ pub mod summaries;
 pub mod tasks;
 pub mod teams;
 pub mod todos;
+pub mod workflows;

--- a/src-tauri/src/commands/workflows.rs
+++ b/src-tauri/src/commands/workflows.rs
@@ -1,0 +1,312 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use crate::utils::silent_command;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowFile {
+    pub name: String,
+    pub filename: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRun {
+    pub id: u64,
+    pub name: String,
+    pub display_title: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub head_branch: String,
+    pub created_at: String,
+    pub url: String,
+    pub workflow_name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunJob {
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunDetail {
+    pub id: u64,
+    pub name: String,
+    pub display_title: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub head_branch: String,
+    pub created_at: String,
+    pub url: String,
+    pub jobs: Vec<WorkflowRunJob>,
+}
+
+/// List all workflow YAML files in `.github/workflows/`.
+#[tauri::command]
+pub async fn cmd_list_workflow_files(cwd: String) -> Result<Vec<WorkflowFile>, String> {
+    let dir = PathBuf::from(&cwd).join(".github").join("workflows");
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut workflows = Vec::new();
+    let entries = std::fs::read_dir(&dir)
+        .map_err(|e| format!("Failed to read workflows dir: {}", e))?;
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if !matches!(ext, "yml" | "yaml") {
+            continue;
+        }
+        let filename = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+        let full_path = path.to_string_lossy().to_string();
+
+        // Try to extract workflow name from the YAML file
+        let name = match std::fs::read_to_string(&path) {
+            Ok(content) => extract_workflow_name(&content).unwrap_or_else(|| filename.clone()),
+            Err(_) => filename.clone(),
+        };
+
+        workflows.push(WorkflowFile {
+            name,
+            filename,
+            path: full_path,
+        });
+    }
+
+    workflows.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(workflows)
+}
+
+fn extract_workflow_name(content: &str) -> Option<String> {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("name:") {
+            let name = trimmed.strip_prefix("name:")?.trim();
+            // Strip surrounding quotes if present
+            let name = name.trim_matches('"').trim_matches('\'');
+            if !name.is_empty() {
+                return Some(name.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// List recent workflow runs, optionally filtered by workflow filename.
+#[tauri::command]
+pub async fn cmd_list_workflow_runs(
+    cwd: String,
+    workflow: Option<String>,
+) -> Result<Vec<WorkflowRun>, String> {
+    let dir = PathBuf::from(&cwd);
+    let workflow_clone = workflow.clone();
+
+    let output = tokio::task::spawn_blocking(move || {
+        let mut args = vec![
+            "run".to_string(),
+            "list".to_string(),
+            "--json".to_string(),
+            "databaseId,name,displayTitle,status,conclusion,headBranch,createdAt,url,workflowName".to_string(),
+            "--limit".to_string(),
+            "30".to_string(),
+        ];
+        if let Some(wf) = &workflow_clone {
+            args.push("--workflow".to_string());
+            args.push(wf.clone());
+        }
+        silent_command("gh")
+            .args(args.iter().map(|s| s.as_str()).collect::<Vec<_>>())
+            .current_dir(&dir)
+            .output()
+    })
+    .await
+    .map_err(|e| format!("Task error: {}", e))?
+    .map_err(|e| format!("gh not found or failed: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh run list failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    #[derive(Deserialize)]
+    struct GhRun {
+        #[serde(rename = "databaseId")]
+        database_id: u64,
+        name: Option<String>,
+        #[serde(rename = "displayTitle")]
+        display_title: Option<String>,
+        status: Option<String>,
+        conclusion: Option<String>,
+        #[serde(rename = "headBranch")]
+        head_branch: Option<String>,
+        #[serde(rename = "createdAt")]
+        created_at: Option<String>,
+        url: Option<String>,
+        #[serde(rename = "workflowName")]
+        workflow_name: Option<String>,
+    }
+
+    let runs: Vec<GhRun> = serde_json::from_str(&stdout)
+        .map_err(|e| format!("Failed to parse gh output: {}", e))?;
+
+    Ok(runs
+        .into_iter()
+        .map(|r| WorkflowRun {
+            id: r.database_id,
+            name: r.name.unwrap_or_default(),
+            display_title: r.display_title.unwrap_or_default(),
+            status: r.status.unwrap_or_default(),
+            conclusion: r.conclusion,
+            head_branch: r.head_branch.unwrap_or_default(),
+            created_at: r.created_at.unwrap_or_default(),
+            url: r.url.unwrap_or_default(),
+            workflow_name: r.workflow_name.unwrap_or_default(),
+        })
+        .collect())
+}
+
+/// Get detailed info about a single workflow run including its jobs.
+#[tauri::command]
+pub async fn cmd_get_workflow_run_detail(
+    cwd: String,
+    run_id: u64,
+) -> Result<WorkflowRunDetail, String> {
+    let dir = PathBuf::from(&cwd);
+    let run_id_str = run_id.to_string();
+
+    let output = tokio::task::spawn_blocking(move || {
+        silent_command("gh")
+            .args([
+                "run",
+                "view",
+                &run_id_str,
+                "--json",
+                "databaseId,name,displayTitle,status,conclusion,headBranch,createdAt,url,jobs",
+            ])
+            .current_dir(&dir)
+            .output()
+    })
+    .await
+    .map_err(|e| format!("Task error: {}", e))?
+    .map_err(|e| format!("gh not found or failed: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh run view failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    #[derive(Deserialize)]
+    struct GhRunDetail {
+        #[serde(rename = "databaseId")]
+        database_id: u64,
+        name: Option<String>,
+        #[serde(rename = "displayTitle")]
+        display_title: Option<String>,
+        status: Option<String>,
+        conclusion: Option<String>,
+        #[serde(rename = "headBranch")]
+        head_branch: Option<String>,
+        #[serde(rename = "createdAt")]
+        created_at: Option<String>,
+        url: Option<String>,
+        #[serde(default)]
+        jobs: Vec<GhJob>,
+    }
+
+    #[derive(Deserialize)]
+    struct GhJob {
+        name: Option<String>,
+        status: Option<String>,
+        conclusion: Option<String>,
+        #[serde(rename = "startedAt")]
+        started_at: Option<String>,
+        #[serde(rename = "completedAt")]
+        completed_at: Option<String>,
+    }
+
+    let run: GhRunDetail = serde_json::from_str(&stdout)
+        .map_err(|e| format!("Failed to parse gh output: {}", e))?;
+
+    Ok(WorkflowRunDetail {
+        id: run.database_id,
+        name: run.name.unwrap_or_default(),
+        display_title: run.display_title.unwrap_or_default(),
+        status: run.status.unwrap_or_default(),
+        conclusion: run.conclusion,
+        head_branch: run.head_branch.unwrap_or_default(),
+        created_at: run.created_at.unwrap_or_default(),
+        url: run.url.unwrap_or_default(),
+        jobs: run
+            .jobs
+            .into_iter()
+            .map(|j| WorkflowRunJob {
+                name: j.name.unwrap_or_default(),
+                status: j.status.unwrap_or_default(),
+                conclusion: j.conclusion,
+                started_at: j.started_at,
+                completed_at: j.completed_at,
+            })
+            .collect(),
+    })
+}
+
+/// Get the log output of a workflow run.
+#[tauri::command]
+pub async fn cmd_get_workflow_run_logs(
+    cwd: String,
+    run_id: u64,
+) -> Result<String, String> {
+    let dir = PathBuf::from(&cwd);
+    let run_id_str = run_id.to_string();
+
+    let output = tokio::task::spawn_blocking(move || {
+        silent_command("gh")
+            .args(["run", "view", &run_id_str, "--log"])
+            .current_dir(&dir)
+            .output()
+    })
+    .await
+    .map_err(|e| format!("Task error: {}", e))?
+    .map_err(|e| format!("gh not found or failed: {}", e))?;
+
+    if !output.status.success() {
+        // Fall back to --log-failed for completed failed runs
+        let dir2 = PathBuf::from(&cwd);
+        let run_id_str2 = run_id.to_string();
+        let output2 = tokio::task::spawn_blocking(move || {
+            silent_command("gh")
+                .args(["run", "view", &run_id_str2, "--log-failed"])
+                .current_dir(&dir2)
+                .output()
+        })
+        .await
+        .map_err(|e| format!("Task error: {}", e))?
+        .map_err(|e| format!("gh not found or failed: {}", e))?;
+
+        if output2.status.success() {
+            return Ok(String::from_utf8_lossy(&output2.stdout).to_string());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh run view --log failed: {}", stderr));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -146,6 +146,10 @@ pub fn run() {
             commands::remote_run::cmd_get_remote_run_status,
             commands::remote_run::cmd_list_repo_secrets,
             commands::remote_run::cmd_set_repo_secret,
+            commands::workflows::cmd_list_workflow_files,
+            commands::workflows::cmd_list_workflow_runs,
+            commands::workflows::cmd_get_workflow_run_detail,
+            commands::workflows::cmd_get_workflow_run_logs,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/layout/BottomPanel.tsx
+++ b/src/components/layout/BottomPanel.tsx
@@ -5,15 +5,18 @@ import { useDebugStore } from "@/stores/debugStore";
 import { GitLogPanel } from "@/components/git/GitLogPanel";
 import { OutputPanel } from "@/components/layout/OutputPanel";
 import { DebugPanel } from "@/components/debug/DebugPanel";
+import { WorkflowsPanel } from "@/components/workflows/WorkflowsPanel";
 
 const BASE_TABS: { id: BottomTab; label: string }[] = [
   { id: "git", label: "Git" },
   { id: "output", label: "Output" },
+  { id: "workflows", label: "Workflows" },
 ];
 
 const tabPlaceholders: Record<BottomTab, string> = {
   git: "Select a project to view git log.",
   output: "No output.",
+  workflows: "Open a project to see workflows.",
   debug: "No debug entries.",
 };
 
@@ -59,6 +62,10 @@ function BottomPanelComponent() {
       ) : activeTab === "output" ? (
         <div className="flex-1 overflow-hidden">
           <OutputPanel />
+        </div>
+      ) : activeTab === "workflows" ? (
+        <div className="flex-1 overflow-hidden">
+          <WorkflowsPanel />
         </div>
       ) : activeTab === "debug" ? (
         <div className="flex-1 overflow-hidden">

--- a/src/components/layout/MainArea.tsx
+++ b/src/components/layout/MainArea.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useCallback, useMemo } from "react";
-import { X, FileText, BookOpen, Settings, GitBranch, History, Terminal, Code2, CheckCircle2, GitPullRequest, Puzzle, CircleDot } from "lucide-react";
+import { X, FileText, BookOpen, Settings, GitBranch, History, Terminal, Code2, CheckCircle2, GitPullRequest, Puzzle, CircleDot, Play } from "lucide-react";
 import { useSessionStore } from "@/stores/sessionStore";
 import type { SessionTab } from "@/stores/sessionStore";
 import { useActiveProjectTabs } from "@/hooks/useActiveProjectTabs";
@@ -17,6 +17,7 @@ import { DiffViewer } from "../git/DiffViewer";
 import { PRDetailView } from "../issues/PRDetailView";
 import { IssueDetailView } from "../issues/IssueDetailView";
 import { ExtensionView } from "../context/ExtensionView";
+import { WorkflowRunView } from "../workflows/WorkflowRunView";
 import { TabContextMenu } from "./TabContextMenu";
 import type { TabCloseAction } from "./TabContextMenu";
 import { CloseTabsWarningDialog } from "./CloseTabsWarningDialog";
@@ -195,6 +196,9 @@ function MainAreaComponent({ projectId: projectIdProp }: { projectId?: string })
               {tab.type === "extension" && (
                 <Puzzle size={10} className={cn("shrink-0", isActive ? accent.icon : "text-text-muted")} />
               )}
+              {tab.type === "workflow-run" && (
+                <Play size={10} className={cn("shrink-0", isActive ? accent.icon : "text-text-muted")} />
+              )}
               {tab.type === "file" && (
                 <Code2 size={10} className={cn("shrink-0", isActive ? "text-[var(--color-accent-secondary)]" : "text-text-muted")} />
               )}
@@ -287,6 +291,8 @@ function MainAreaComponent({ projectId: projectIdProp }: { projectId?: string })
                 <IssueDetailView tab={tab} />
               ) : tab.type === "extension" ? (
                 <ExtensionView tab={tab} />
+              ) : tab.type === "workflow-run" ? (
+                <WorkflowRunView tab={tab} />
               ) : (
                 <TerminalView
                   sessionId={tab.id}

--- a/src/components/workflows/WorkflowRunView.tsx
+++ b/src/components/workflows/WorkflowRunView.tsx
@@ -1,0 +1,158 @@
+import { ExternalLink, RefreshCw } from "lucide-react";
+import { useWorkflowRunDetail, useWorkflowRunLogs } from "@/hooks/useClaudeData";
+import { useProjectsStore } from "@/stores/projectsStore";
+import type { SessionTab } from "@/stores/sessionStore";
+import type { WorkflowRunJob } from "@/lib/tauri";
+
+function StatusIcon({ status, conclusion, size = 14 }: { status: string; conclusion: string | null; size?: number }) {
+  if (status === "completed") {
+    if (conclusion === "success") {
+      return (
+        <svg width={size} height={size} viewBox="0 0 14 14" className="shrink-0">
+          <circle cx="7" cy="7" r="6" fill="none" stroke="var(--color-status-success)" strokeWidth="1.5" />
+          <path d="M4 7l2 2 4-4" fill="none" stroke="var(--color-status-success)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      );
+    }
+    return (
+      <svg width={size} height={size} viewBox="0 0 14 14" className="shrink-0">
+        <circle cx="7" cy="7" r="6" fill="none" stroke="var(--color-status-error)" strokeWidth="1.5" />
+        <path d="M5 5l4 4M9 5l-4 4" fill="none" stroke="var(--color-status-error)" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    );
+  }
+  if (status === "in_progress") {
+    return (
+      <svg width={size} height={size} viewBox="0 0 14 14" className="shrink-0 animate-spin">
+        <circle cx="7" cy="7" r="6" fill="none" stroke="var(--color-status-warning)" strokeWidth="1.5" strokeDasharray="20 18" />
+      </svg>
+    );
+  }
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" className="shrink-0">
+      <circle cx="7" cy="7" r="6" fill="none" stroke="var(--color-text-muted)" strokeWidth="1.5" />
+      <circle cx="7" cy="7" r="2" fill="var(--color-text-muted)" />
+    </svg>
+  );
+}
+
+function JobItem({ job }: { job: WorkflowRunJob }) {
+  const duration = (() => {
+    if (!job.startedAt || !job.completedAt) return null;
+    const start = new Date(job.startedAt).getTime();
+    const end = new Date(job.completedAt).getTime();
+    const secs = Math.floor((end - start) / 1000);
+    if (secs < 60) return `${secs}s`;
+    const mins = Math.floor(secs / 60);
+    const remSecs = secs % 60;
+    return `${mins}m ${remSecs}s`;
+  })();
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5">
+      <StatusIcon status={job.status} conclusion={job.conclusion} />
+      <span className="text-xs text-text-primary flex-1">{job.name}</span>
+      {duration && (
+        <span className="text-[10px] text-text-muted">{duration}</span>
+      )}
+    </div>
+  );
+}
+
+export function WorkflowRunView({ tab }: { tab: SessionTab }) {
+  const activeProjectDir = useProjectsStore((s) =>
+    s.projects.find((p) => p.id === s.activeProjectId)?.path ?? null
+  );
+  const runId = tab.workflowRunId ?? 0;
+  const runUrl = tab.workflowRunUrl;
+
+  const { data: detail, isLoading: detailLoading, refetch: refetchDetail } = useWorkflowRunDetail(activeProjectDir, runId);
+  const { data: logs, isLoading: logsLoading, refetch: refetchLogs } = useWorkflowRunLogs(activeProjectDir, runId);
+
+  const handleRefresh = () => {
+    refetchDetail();
+    refetchLogs();
+  };
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden bg-bg-base">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border-muted bg-bg-surface shrink-0">
+        {detail && (
+          <StatusIcon status={detail.status} conclusion={detail.conclusion} size={18} />
+        )}
+        <div className="flex-1 min-w-0">
+          <h2 className="text-sm font-medium text-text-primary truncate">
+            {detail?.displayTitle || detail?.name || `Run #${runId}`}
+          </h2>
+          {detail && (
+            <div className="flex items-center gap-2 mt-0.5">
+              <span className="text-[10px] text-text-muted">
+                {detail.headBranch} · {detail.status}
+                {detail.conclusion ? ` · ${detail.conclusion}` : ""}
+              </span>
+            </div>
+          )}
+        </div>
+        <button
+          onClick={handleRefresh}
+          className="text-text-muted hover:text-text-secondary transition-colors p-1"
+          title="Refresh"
+        >
+          <RefreshCw size={14} />
+        </button>
+        {runUrl && (
+          <a
+            href={runUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-text-muted hover:text-accent-primary transition-colors p-1"
+            title="Open in browser"
+          >
+            <ExternalLink size={14} />
+          </a>
+        )}
+      </div>
+
+      {detailLoading && (
+        <div className="p-4 text-xs text-text-muted">Loading run details...</div>
+      )}
+
+      {/* Jobs */}
+      {detail && detail.jobs.length > 0 && (
+        <div className="border-b border-border-muted">
+          <div className="px-3 py-1.5 text-[10px] font-medium text-text-muted uppercase tracking-wide bg-bg-surface">
+            Jobs
+          </div>
+          {detail.jobs.map((job, i) => (
+            <JobItem key={i} job={job} />
+          ))}
+        </div>
+      )}
+
+      {/* Logs */}
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="px-3 py-1.5 text-[10px] font-medium text-text-muted uppercase tracking-wide bg-bg-surface border-b border-border-muted shrink-0">
+          Output
+        </div>
+        <div className="flex-1 overflow-auto">
+          {logsLoading && (
+            <div className="p-4 text-xs text-text-muted">Loading logs...</div>
+          )}
+          {!logsLoading && logs && (
+            <pre className="p-3 text-[11px] font-mono text-text-secondary whitespace-pre-wrap break-words leading-relaxed">
+              {logs}
+            </pre>
+          )}
+          {!logsLoading && !logs && (
+            <div className="p-4 text-xs text-text-muted text-center">
+              {detail?.status === "in_progress"
+                ? "Logs will be available once the run completes."
+                : "No logs available."}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workflows/WorkflowsPanel.tsx
+++ b/src/components/workflows/WorkflowsPanel.tsx
@@ -1,0 +1,302 @@
+import { useState, useCallback } from "react";
+import { RefreshCw, ExternalLink, Play } from "lucide-react";
+import { useWorkflowFiles, useWorkflowRuns } from "@/hooks/useClaudeData";
+import { useProjectsStore } from "@/stores/projectsStore";
+import { useSessionStore } from "@/stores/sessionStore";
+import type { SessionTab } from "@/stores/sessionStore";
+import type { WorkflowFile, WorkflowRun } from "@/lib/tauri";
+import { pathToProjectId, cn } from "@/lib/utils";
+
+function formatTimeAgo(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`;
+  return `${Math.floor(diffDays / 365)}y ago`;
+}
+
+function StatusIcon({ status, conclusion }: { status: string; conclusion: string | null }) {
+  if (status === "completed") {
+    if (conclusion === "success") {
+      return (
+        <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0">
+          <circle cx="7" cy="7" r="6" fill="none" stroke="var(--color-status-success)" strokeWidth="1.5" />
+          <path d="M4 7l2 2 4-4" fill="none" stroke="var(--color-status-success)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      );
+    }
+    return (
+      <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0">
+        <circle cx="7" cy="7" r="6" fill="none" stroke="var(--color-status-error)" strokeWidth="1.5" />
+        <path d="M5 5l4 4M9 5l-4 4" fill="none" stroke="var(--color-status-error)" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    );
+  }
+  if (status === "in_progress") {
+    return (
+      <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0 animate-spin">
+        <circle cx="7" cy="7" r="6" fill="none" stroke="var(--color-status-warning)" strokeWidth="1.5" strokeDasharray="20 18" />
+      </svg>
+    );
+  }
+  // queued / waiting / pending
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0">
+      <circle cx="7" cy="7" r="6" fill="none" stroke="var(--color-text-muted)" strokeWidth="1.5" />
+      <circle cx="7" cy="7" r="2" fill="var(--color-text-muted)" />
+    </svg>
+  );
+}
+
+export function WorkflowsPanel() {
+  const activeProjectDir = useProjectsStore((s) =>
+    s.projects.find((p) => p.id === s.activeProjectId)?.path ?? null
+  );
+  const openTab = useSessionStore((s) => s.openTab);
+  const [selectedWorkflow, setSelectedWorkflow] = useState<WorkflowFile | null>(null);
+
+  const {
+    data: workflowFiles,
+    isLoading: filesLoading,
+    error: filesError,
+    refetch: refetchFiles,
+  } = useWorkflowFiles(activeProjectDir);
+
+  const {
+    data: runs,
+    isLoading: runsLoading,
+    error: runsError,
+    refetch: refetchRuns,
+  } = useWorkflowRuns(
+    activeProjectDir,
+    selectedWorkflow?.filename
+  );
+
+  const handleWorkflowClick = useCallback((wf: WorkflowFile) => {
+    setSelectedWorkflow(wf);
+  }, []);
+
+  const handleWorkflowDoubleClick = useCallback((wf: WorkflowFile) => {
+    if (!activeProjectDir) return;
+    const projectId = pathToProjectId(activeProjectDir);
+    const tabId = `file:${wf.path}`;
+    const tab: SessionTab = {
+      id: tabId,
+      type: "file",
+      title: wf.filename,
+      filePath: wf.path,
+      projectDir: activeProjectDir,
+    };
+    openTab(tab, projectId);
+  }, [activeProjectDir, openTab]);
+
+  const handleRunClick = useCallback((run: WorkflowRun) => {
+    if (!activeProjectDir) return;
+    const projectId = pathToProjectId(activeProjectDir);
+    const tabId = `workflow-run:${run.id}`;
+    const tab: SessionTab = {
+      id: tabId,
+      type: "workflow-run",
+      title: `Run #${run.id}`,
+      projectDir: activeProjectDir,
+      workflowRunId: run.id,
+      workflowRunUrl: run.url,
+    };
+    openTab(tab, projectId);
+  }, [activeProjectDir, openTab]);
+
+  const handleRefresh = useCallback(() => {
+    refetchFiles();
+    refetchRuns();
+  }, [refetchFiles, refetchRuns]);
+
+  if (!activeProjectDir) {
+    return (
+      <div className="flex items-center justify-center h-full p-3 text-xs text-text-muted">
+        Open a project to see workflows
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full overflow-hidden">
+      {/* Left pane — workflow list */}
+      <div className="w-52 shrink-0 flex flex-col border-r border-border-muted">
+        <div className="flex items-center h-7 px-2 border-b border-border-muted">
+          <span className="text-[10px] font-medium text-text-secondary uppercase tracking-wide flex-1">
+            Workflows
+          </span>
+          <button
+            onClick={handleRefresh}
+            className="text-text-muted hover:text-text-secondary transition-colors"
+            title="Refresh"
+          >
+            <RefreshCw size={10} />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {filesLoading && (
+            <div className="p-2 text-[10px] text-text-muted">Loading...</div>
+          )}
+          {filesError && (
+            <div className="p-2 text-[10px] text-status-error">
+              Failed to load workflows
+            </div>
+          )}
+          {!filesLoading && !filesError && (!workflowFiles || workflowFiles.length === 0) && (
+            <div className="p-3 text-[10px] text-text-muted text-center">
+              No workflow files found in .github/workflows/
+            </div>
+          )}
+          {/* "All" option */}
+          {workflowFiles && workflowFiles.length > 0 && (
+            <button
+              onClick={() => setSelectedWorkflow(null)}
+              className={cn(
+                "w-full text-left px-2 py-1.5 text-xs transition-all duration-150 border-b border-border-muted",
+                selectedWorkflow === null
+                  ? "bg-accent-primary/10 text-accent-primary"
+                  : "text-text-secondary hover:bg-bg-raised/50"
+              )}
+            >
+              <div className="flex items-center gap-1.5">
+                <Play size={10} className="shrink-0 text-text-muted" />
+                <span className="truncate font-medium">All workflows</span>
+              </div>
+            </button>
+          )}
+          {workflowFiles?.map((wf) => (
+            <WorkflowFileItem
+              key={wf.filename}
+              workflow={wf}
+              isSelected={selectedWorkflow?.filename === wf.filename}
+              latestRun={runs?.find((r) => r.workflowName === wf.name)}
+              onClick={() => handleWorkflowClick(wf)}
+              onDoubleClick={() => handleWorkflowDoubleClick(wf)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Right pane — runs list */}
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex items-center h-7 px-2 border-b border-border-muted">
+          <span className="text-[10px] font-medium text-text-secondary uppercase tracking-wide flex-1">
+            {selectedWorkflow ? selectedWorkflow.name : "All Runs"}
+          </span>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {runsLoading && (
+            <div className="p-2 text-[10px] text-text-muted">Loading runs...</div>
+          )}
+          {runsError && (
+            <div className="p-2 text-[10px] text-status-error">
+              {runsError instanceof Error ? runsError.message : "Failed to load runs"}
+              <p className="mt-1 text-text-muted">
+                Make sure GitHub CLI is installed and authenticated.
+              </p>
+            </div>
+          )}
+          {!runsLoading && !runsError && (!runs || runs.length === 0) && (
+            <div className="p-3 text-[10px] text-text-muted text-center">
+              No workflow runs found
+            </div>
+          )}
+          {runs?.map((run) => (
+            <RunItem
+              key={run.id}
+              run={run}
+              onClick={() => handleRunClick(run)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WorkflowFileItem({
+  workflow,
+  isSelected,
+  latestRun,
+  onClick,
+  onDoubleClick,
+}: {
+  workflow: WorkflowFile;
+  isSelected: boolean;
+  latestRun?: WorkflowRun;
+  onClick: () => void;
+  onDoubleClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      className={cn(
+        "w-full text-left px-2 py-1.5 text-xs transition-all duration-150 border-b border-border-muted",
+        isSelected
+          ? "bg-accent-primary/10 text-accent-primary"
+          : "text-text-secondary hover:bg-bg-raised/50"
+      )}
+    >
+      <div className="flex items-center gap-1.5">
+        {latestRun ? (
+          <StatusIcon status={latestRun.status} conclusion={latestRun.conclusion} />
+        ) : (
+          <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0">
+            <circle cx="7" cy="7" r="6" fill="none" stroke="var(--color-text-muted)" strokeWidth="1.5" strokeDasharray="3 3" />
+          </svg>
+        )}
+        <span className="truncate">{workflow.name}</span>
+      </div>
+    </button>
+  );
+}
+
+function RunItem({
+  run,
+  onClick,
+}: {
+  run: WorkflowRun;
+  onClick: () => void;
+}) {
+  return (
+    <div
+      className="px-3 py-2 border-b border-border-muted hover:bg-bg-raised/50 transition-all duration-150 cursor-pointer"
+      onClick={onClick}
+    >
+      <div className="flex items-start gap-2">
+        <span className="mt-0.5">
+          <StatusIcon status={run.status} conclusion={run.conclusion} />
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="text-xs text-text-primary truncate">
+            {run.displayTitle || run.name}
+          </p>
+          <div className="flex items-center gap-2 mt-0.5">
+            <span className="text-[10px] text-text-muted">
+              {run.workflowName} · {run.headBranch} · {formatTimeAgo(run.createdAt)}
+            </span>
+          </div>
+        </div>
+        <a
+          href={run.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="mt-0.5 text-text-muted hover:text-accent-primary transition-colors"
+          title="Open in browser"
+        >
+          <ExternalLink size={12} />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useClaudeData.ts
+++ b/src/hooks/useClaudeData.ts
@@ -371,6 +371,48 @@ export function useJiraIssueDetail(enabled: boolean, baseUrl: string, email: str
   });
 }
 
+// ---- Workflow Hooks ----
+
+export function useWorkflowFiles(cwd: string | null) {
+  return useQuery({
+    queryKey: ["workflow-files", cwd],
+    queryFn: () => tauri.listWorkflowFiles(cwd!),
+    enabled: !!cwd,
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
+export function useWorkflowRuns(cwd: string | null, workflow?: string) {
+  return useQuery({
+    queryKey: ["workflow-runs", cwd, workflow],
+    queryFn: () => tauri.listWorkflowRuns(cwd!, workflow),
+    enabled: !!cwd,
+    staleTime: 30_000,
+    retry: false,
+  });
+}
+
+export function useWorkflowRunDetail(cwd: string | null, runId: number) {
+  return useQuery({
+    queryKey: ["workflow-run-detail", cwd, runId],
+    queryFn: () => tauri.getWorkflowRunDetail(cwd!, runId),
+    enabled: !!cwd && runId > 0,
+    staleTime: 30_000,
+    retry: false,
+  });
+}
+
+export function useWorkflowRunLogs(cwd: string | null, runId: number) {
+  return useQuery({
+    queryKey: ["workflow-run-logs", cwd, runId],
+    queryFn: () => tauri.getWorkflowRunLogs(cwd!, runId),
+    enabled: !!cwd && runId > 0,
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
 // ---- Extension Hooks ----
 
 export function useExtensions(projectDir: string | null) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -696,6 +696,62 @@ export function loadExtensions(projectDir: string): Promise<ClaudeExtension[]> {
   return invoke("cmd_load_extensions", { projectDir });
 }
 
+// ---- Workflow Types ----
+
+export interface WorkflowFile {
+  name: string;
+  filename: string;
+  path: string;
+}
+
+export interface WorkflowRun {
+  id: number;
+  name: string;
+  displayTitle: string;
+  status: string;
+  conclusion: string | null;
+  headBranch: string;
+  createdAt: string;
+  url: string;
+  workflowName: string;
+}
+
+export interface WorkflowRunJob {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface WorkflowRunDetail {
+  id: number;
+  name: string;
+  displayTitle: string;
+  status: string;
+  conclusion: string | null;
+  headBranch: string;
+  createdAt: string;
+  url: string;
+  jobs: WorkflowRunJob[];
+}
+
+export function listWorkflowFiles(cwd: string): Promise<WorkflowFile[]> {
+  return invoke("cmd_list_workflow_files", { cwd });
+}
+
+export function listWorkflowRuns(cwd: string, workflow?: string): Promise<WorkflowRun[]> {
+  return invoke("cmd_list_workflow_runs", { cwd, workflow: workflow ?? null });
+}
+
+export function getWorkflowRunDetail(cwd: string, runId: number): Promise<WorkflowRunDetail> {
+  return invoke("cmd_get_workflow_run_detail", { cwd, runId });
+}
+
+export function getWorkflowRunLogs(cwd: string, runId: number): Promise<string> {
+  return invoke("cmd_get_workflow_run_logs", { cwd, runId });
+}
+
 // ---- Remote Run ----
 
 export interface RemoteRunResult {

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -4,7 +4,7 @@ import { useNotificationStore } from "./notificationStore";
 
 export interface SessionTab {
   id: string;
-  type?: "terminal" | "plan" | "readme" | "settings" | "diff" | "session-view" | "file" | "summary" | "pr-detail" | "extension" | "issue-detail";
+  type?: "terminal" | "plan" | "readme" | "settings" | "diff" | "session-view" | "file" | "summary" | "pr-detail" | "extension" | "issue-detail" | "workflow-run";
   projectDir: string;
   sessionId?: string;
   title: string;
@@ -26,6 +26,8 @@ export interface SessionTab {
   remoteRunUrl?: string; // URL to the workflow run on GitHub
   remoteRunStatus?: "queued" | "in_progress" | "completed";
   remoteRunConclusion?: "success" | "failure" | "cancelled" | null;
+  workflowRunId?: number; // only for type === "workflow-run"
+  workflowRunUrl?: string; // external URL for the workflow run
 }
 
 interface SessionStore {

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 export type SidebarView = "sessions" | "git" | "prs" | "issues" | "files";
 export type RightTab = "context" | "teams" | "plans" | "docs" | "notes";
-export type BottomTab = "git" | "output" | "debug";
+export type BottomTab = "git" | "output" | "workflows" | "debug";
 
 export interface PendingNoteRef {
   filePath: string;


### PR DESCRIPTION
Add a new "Workflows" tab in the bottom panel that shows GitHub Actions
workflows for the current project. Features:

- Left pane lists workflow YAML files from .github/workflows/ with
  status indicators (green check / red x / spinner) from latest run
- Click a workflow to filter its runs; double-click to open the YAML
  file in the editor tabs
- Right pane shows workflow runs with status, branch, and timestamp
- Click a run to open its detail + logs in a new center tab
- External link button on each run opens it in the browser
- Rust backend uses `gh` CLI for run list/view/logs

https://claude.ai/code/session_01Bv1hR1jgdaxwAzD9NdMeVR