### PR TITLE
feat: watch .git/HEAD for branch changes and auto-update UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,9 @@ npm run tauri build      # release build
 
 | Area | Files | Purpose |
 |------|-------|---------|
-| Entry | `src-tauri/src/lib.rs` | Plugin init, PtyState, hook setup on launch, starts claude_watcher |
+| Entry | `src-tauri/src/lib.rs` | Plugin init, PtyState, GitWatcherState, hook setup on launch, starts claude_watcher |
 | Commands | `commands/pty.rs` | PTY spawn/resize/write/kill via portable-pty (ConPTY) |
-| | `commands/git.rs` | git status/diff/log/branches/worktrees/fetch/pull/rebase + Claude git actions |
+| | `commands/git.rs` | git status/diff/log/branches/worktrees/fetch/pull/rebase + Claude git actions + `cmd_watch_git_head` |
 | | `commands/sessions.rs` | Load session index + transcripts from `~/.claude/projects/` |
 | | `commands/integrations.rs` | GitHub device flow, Linear, Jira auth; Windows Credential Manager |
 | | `commands/hooks.rs` | Install/remove Claude CLI hooks in `~/.claude/theassociate/` |
@@ -106,6 +106,7 @@ npm run tauri build      # release build
 | Data layer | `data/` module | File I/O + parsing for each domain: `sessions`, `transcripts`, `teams`, `tasks`, `inboxes`, `todos`, `plans`, `notes`, `summaries`, `projects`, `git`, `hook_state`, `watcher_state`, `path_encoding` |
 | Models | `models/` module | Serde structs: `session`, `transcript`, `team`, `task`, `inbox`, `todo`, `plan`, `note`, `summary`, `git`, `hook_event` |
 | Watcher | `watcher/claude_watcher.rs` | Watches `~/.claude/` dirs (teams, tasks, projects, todos, plans, notes, theassociate); emits Tauri events on file changes; parses `hook-events.jsonl` for session/subagent lifecycle |
+| Git watcher | `watcher/git_watcher.rs` | Watches `.git/HEAD` for active project; emits `git-branch-changed` when branch switches; managed state replaced when project changes |
 
 ## Component areas
 
@@ -139,6 +140,7 @@ npm run tauri build      # release build
 7. **pathToProjectId encoding** — `C:\dev\ide` → `C--dev-ide`; `C:\dev\apex_3.11.0` → `C--dev-apex-3-11-0`; path separators, `.`, and `_` all become `-`; `lib/utils.ts` must stay in sync with Rust `data/path_encoding.rs`
 8. **Hook events via file watcher** — `hook-events.jsonl` is append-only; watcher tracks file offset to read only new lines
 9. **Claude watcher auto-starts** — `lib.rs` calls `start_claude_watcher()` in `.setup()`; also auto-installs hooks via `cmd_setup_hooks()`
+10. **Git branch watcher** — `useGitBranchWatcher()` calls `cmd_watch_git_head(cwd)` when active project changes; watches `.git/HEAD` via `notify` crate; emits `git-branch-changed` event; old watcher dropped when project switches
 
 ## Research reference
 

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,5 +1,6 @@
 use crate::data::git;
 use crate::models::git::{DiffLine, GitStatus};
+use crate::watcher::git_watcher::GitWatcherState;
 use std::fs;
 use std::path::PathBuf;
 
@@ -536,4 +537,13 @@ pub async fn cmd_claude_git_action(cwd: String, action: String) -> Result<String
             combined.trim().to_string()
         })
     }
+}
+
+#[tauri::command]
+pub async fn cmd_watch_git_head(
+    cwd: String,
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, GitWatcherState>,
+) -> Result<(), String> {
+    crate::watcher::git_watcher::start_git_head_watch(app_handle, cwd, &state)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub fn run() {
         .manage(PtyState(std::sync::Arc::new(std::sync::Mutex::new(
             std::collections::HashMap::new(),
         ))))
+        .manage(watcher::git_watcher::GitWatcherState::new())
         .setup(|app| {
             // Create a Start Menu shortcut with AUMID so Windows toast notifications
             // appear as "The Associate Studio" rather than PowerShell.
@@ -86,6 +87,7 @@ pub fn run() {
             commands::git::cmd_git_ignore,
             commands::git::cmd_git_exclude,
             commands::git::cmd_git_rebase,
+            commands::git::cmd_watch_git_head,
             commands::pty::pty_spawn,
             commands::pty::pty_resize,
             commands::pty::pty_write,

--- a/src-tauri/src/watcher/git_watcher.rs
+++ b/src-tauri/src/watcher/git_watcher.rs
@@ -1,0 +1,113 @@
+use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tauri::Emitter;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GitBranchPayload {
+    pub cwd: String,
+    pub branch: String,
+}
+
+/// Holds the active git HEAD watcher so it can be replaced when the project changes.
+struct GitWatcherInner {
+    _watcher: RecommendedWatcher,
+    _cwd: String,
+}
+
+pub struct GitWatcherState(pub Arc<Mutex<Option<GitWatcherInner>>>);
+
+impl GitWatcherState {
+    pub fn new() -> Self {
+        Self(Arc::new(Mutex::new(None)))
+    }
+}
+
+/// Read the current branch from the HEAD file inside the given git directory.
+fn read_head_branch(git_dir: &PathBuf) -> Option<String> {
+    let head_path = git_dir.join("HEAD");
+    let content = std::fs::read_to_string(&head_path).ok()?;
+    let trimmed = content.trim();
+    if let Some(ref_name) = trimmed.strip_prefix("ref: refs/heads/") {
+        Some(ref_name.to_string())
+    } else if !trimmed.is_empty() {
+        // Detached HEAD — return short SHA
+        Some(trimmed.chars().take(8).collect())
+    } else {
+        None
+    }
+}
+
+/// Start watching `.git/HEAD` for the given project directory.
+/// Replaces any existing watcher.  Emits `"git-branch-changed"` when the
+/// branch changes.
+pub fn start_git_head_watch(
+    app_handle: tauri::AppHandle,
+    cwd: String,
+    state: &GitWatcherState,
+) -> Result<(), String> {
+    // Drop the previous watcher (stops its thread)
+    if let Ok(mut guard) = state.0.lock() {
+        *guard = None;
+    }
+
+    // Resolve the actual git directory (handles worktrees transparently)
+    let repo = git2::Repository::discover(&cwd)
+        .map_err(|e| format!("Not a git repository: {}", e))?;
+    let git_dir = repo.path().to_path_buf();
+
+    let initial_branch = read_head_branch(&git_dir).unwrap_or_default();
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut watcher = RecommendedWatcher::new(
+        tx,
+        Config::default().with_poll_interval(Duration::from_millis(500)),
+    )
+    .map_err(|e| format!("Failed to create git watcher: {}", e))?;
+
+    // Watch the git directory (non-recursive) so we catch HEAD changes even
+    // when git performs atomic rename operations.
+    watcher
+        .watch(&git_dir, RecursiveMode::NonRecursive)
+        .map_err(|e| format!("Failed to watch git dir: {}", e))?;
+
+    let cwd_for_thread = cwd.clone();
+    let git_dir_for_thread = git_dir.clone();
+
+    std::thread::spawn(move || {
+        let mut last_branch = initial_branch;
+        // Small debounce: collapse rapid successive events
+        let debounce = Duration::from_millis(100);
+
+        for result in &rx {
+            if result.is_err() {
+                continue;
+            }
+
+            // Drain any queued events within the debounce window
+            std::thread::sleep(debounce);
+            while rx.try_recv().is_ok() {}
+
+            if let Some(current) = read_head_branch(&git_dir_for_thread) {
+                if current != last_branch {
+                    last_branch = current.clone();
+                    let payload = GitBranchPayload {
+                        cwd: cwd_for_thread.clone(),
+                        branch: current,
+                    };
+                    let _ = app_handle.emit("git-branch-changed", &payload);
+                }
+            }
+        }
+    });
+
+    if let Ok(mut guard) = state.0.lock() {
+        *guard = Some(GitWatcherInner {
+            _watcher: watcher,
+            _cwd: cwd,
+        });
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/watcher/mod.rs
+++ b/src-tauri/src/watcher/mod.rs
@@ -1,1 +1,2 @@
 pub mod claude_watcher;
+pub mod git_watcher;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { StatusBar } from "./components/shell/StatusBar";
 import { IDELayout } from "./components/layout/IDELayout";
 import { CommandPalette } from "./components/shell/CommandPalette";
 import { useKeyBindings } from "./hooks/useKeyBindings";
-import { useClaudeWatcher } from "./hooks/useClaudeData";
+import { useClaudeWatcher, useGitBranchWatcher } from "./hooks/useClaudeData";
 import { useSettingsStore } from "./stores/settingsStore";
 import { useProjectsStore } from "./stores/projectsStore";
 import { useIssueFilterStore } from "./stores/issueFilterStore";
@@ -46,6 +46,7 @@ const queryClient = new QueryClient({
 function IDEShell() {
   useKeyBindings();
   useClaudeWatcher();
+  useGitBranchWatcher();
   const loadFromDisk = useSettingsStore((s) => s.loadFromDisk);
   const loadProjects = useProjectsStore((s) => s.loadProjects);
   const loadRecentFromDisk = useProjectsStore((s) => s.loadRecentFromDisk);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -420,6 +420,10 @@ export async function gitExclude(cwd: string, filePath: string): Promise<string>
   return invoke("cmd_git_exclude", { cwd, filePath });
 }
 
+export async function watchGitHead(cwd: string): Promise<void> {
+  return invoke("cmd_watch_git_head", { cwd });
+}
+
 // ─── PR / Issues Types ────────────────────────────────────────────────────────
 
 export interface PullRequest {


### PR DESCRIPTION
Add a file watcher on the active project's .git directory to detect
branch switches. When the HEAD reference changes, a "git-branch-changed"
Tauri event is emitted, which invalidates all git-related React Query
caches. This causes the TitleBar branch chip, StatusBar, GitStatusPanel,
and GitLogPanel to automatically refresh without polling.

- New Rust module: watcher/git_watcher.rs (GitWatcherState managed state)
- New Tauri command: cmd_watch_git_head(cwd) starts/replaces the watcher
- Frontend: useGitBranchWatcher() hook calls watchGitHead on project change
- Event listener in useClaudeWatcher invalidates git-current-branch,
  git-branches, git-status, git-log, and git-remote-branches queries

https://claude.ai/code/session_01LNChPyeHNqJMaZg49ZvyKZ